### PR TITLE
Fixed member errors for Downpacket and Uppacket for gcc

### DIFF
--- a/src/artery/application/Asn1PacketVisitor.h
+++ b/src/artery/application/Asn1PacketVisitor.h
@@ -40,7 +40,7 @@ struct Asn1PacketVisitor : public boost::static_visitor<T*>
         byte_buffer* ptr = packet[vanetza::OsiLayer::Application].ptr();
         auto impl = dynamic_cast<byte_buffer_impl*>(ptr);
         if (impl) {
-            return &(impl->m_wrapper);
+            return &*(impl->m_wrapper);
         } else {
             opp_error("ChunkPacket doesn't contain requested ASN.1 structure");
             return nullptr;

--- a/src/artery/application/CaService.cc
+++ b/src/artery/application/CaService.cc
@@ -51,7 +51,7 @@ void CaService::trigger()
 	checkTriggeringConditions(getFacilities().getVehicleDataProvider(), simTime());
 }
 
-void CaService::indicate(const vanetza::btp::DataIndication& ind, std::unique_ptr<vanetza::btp::UpPacket> packet)
+void CaService::indicate(const vanetza::btp::DataIndication& ind, std::unique_ptr<UpPacket> packet)
 {
 	Asn1PacketVisitor<vanetza::asn1::Cam> visitor;
 	vanetza::asn1::Cam* cam = boost::apply_visitor(visitor, *packet);

--- a/src/artery/application/CaService.h
+++ b/src/artery/application/CaService.h
@@ -27,12 +27,13 @@
 #include <vanetza/units/velocity.hpp>
 #include <simtime_t.h>
 
+using UpPacket = vanetza::PacketVariant;
 
 class CaService : public ItsG5BaseService
 {
 	public:
 		CaService();
-		void indicate(const vanetza::btp::DataIndication&, std::unique_ptr<vanetza::btp::UpPacket>) override;
+		void indicate(const vanetza::btp::DataIndication&, std::unique_ptr<UpPacket>) override;
 		void trigger() override;
 
 	private:

--- a/src/artery/application/DenmService.cc
+++ b/src/artery/application/DenmService.cc
@@ -22,7 +22,7 @@ Define_Module(DenmService);
 
 static const simsignal_t scSignalDenmReceived = cComponent::registerSignal("DenmService.received");
 
-void DenmService::indicate(const vanetza::btp::DataIndication& indication, std::unique_ptr<vanetza::btp::UpPacket> packet)
+void DenmService::indicate(const vanetza::btp::DataIndication& indication, std::unique_ptr<UpPacket> packet)
 {
     Asn1PacketVisitor<vanetza::asn1::Denm> visitor;
     vanetza::asn1::Denm* denm = boost::apply_visitor(visitor, *packet);

--- a/src/artery/application/DenmService.h
+++ b/src/artery/application/DenmService.h
@@ -22,7 +22,7 @@
 class DenmService : public ItsG5BaseService
 {
     public:
-        void indicate(const vanetza::btp::DataIndication&, std::unique_ptr<vanetza::btp::UpPacket>) override;
+        void indicate(const vanetza::btp::DataIndication&, std::unique_ptr<UpPacket>) override;
 };
 
 #endif

--- a/src/artery/application/ItsG5BaseService.cc
+++ b/src/artery/application/ItsG5BaseService.cc
@@ -79,12 +79,12 @@ void ItsG5BaseService::trigger()
 {
 }
 
-void ItsG5BaseService::request(const vanetza::btp::DataRequestB& req, std::unique_ptr<vanetza::btp::DownPacket> packet)
+void ItsG5BaseService::request(const vanetza::btp::DataRequestB& req, std::unique_ptr<DownPacket> packet)
 {
 	assert(m_middleware);
 	m_middleware->request(req, std::move(packet));
 }
 
-void ItsG5BaseService::indicate(const vanetza::btp::DataIndication& ind, std::unique_ptr<vanetza::btp::UpPacket> packet)
+void ItsG5BaseService::indicate(const vanetza::btp::DataIndication& ind, std::unique_ptr<UpPacket> packet)
 {
 }

--- a/src/artery/application/ItsG5BaseService.h
+++ b/src/artery/application/ItsG5BaseService.h
@@ -26,6 +26,9 @@
 #include "Facilities.h"
 #include "ItsG5Middleware.h"
 
+using DownPacket = vanetza::ChunkPacket;
+using UpPacket = vanetza::PacketVariant;
+
 class ItsG5BaseService :
 	public cSimpleModule, public cListener,
 	public vanetza::btp::IndicationInterface
@@ -40,8 +43,8 @@ class ItsG5BaseService :
 
 	protected:
 		void initialize() override;
-		void request(const vanetza::btp::DataRequestB&, std::unique_ptr<vanetza::btp::DownPacket>);
-		void indicate(const vanetza::btp::DataIndication&, std::unique_ptr<vanetza::btp::UpPacket>) override;
+		void request(const vanetza::btp::DataRequestB&, std::unique_ptr<DownPacket>);
+		void indicate(const vanetza::btp::DataIndication&, std::unique_ptr<UpPacket>) override;
 		Facilities& getFacilities();
 		port_type getPortNumber() const;
 		cModule* findHost();

--- a/src/artery/application/ItsG5Middleware.cc
+++ b/src/artery/application/ItsG5Middleware.cc
@@ -104,7 +104,7 @@ void ItsG5Middleware::request(const vanetza::access::DataRequest& req,
 	sendDown(net);
 }
 
-void ItsG5Middleware::request(const vanetza::btp::DataRequestB& req, std::unique_ptr<vanetza::btp::DownPacket> payload)
+void ItsG5Middleware::request(const vanetza::btp::DataRequestB& req, std::unique_ptr<DownPacket> payload)
 {
 	Enter_Method("request");
 	using namespace vanetza;

--- a/src/artery/application/ItsG5Middleware.h
+++ b/src/artery/application/ItsG5Middleware.h
@@ -36,6 +36,9 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <map>
 #include <memory>
+#include <vanetza/net/packet_variant.hpp>
+
+using DownPacket = vanetza::ChunkPacket;
 
 // forward declarations
 namespace Veins { class TraCIMobility; }
@@ -52,7 +55,7 @@ class ItsG5Middleware : public BaseApplLayer, public vanetza::access::Interface,
 
 		ItsG5Middleware();
 		void request(const vanetza::access::DataRequest&, std::unique_ptr<vanetza::geonet::DownPacket>) override;
-		void request(const vanetza::btp::DataRequestB&, std::unique_ptr<vanetza::btp::DownPacket>) override;
+		void request(const vanetza::btp::DataRequestB&, std::unique_ptr<DownPacket>) override;
 		Facilities* getFacilities() { return mFacilities.get(); }
 		port_type getPortNumber(const ItsG5BaseService*) const;
 

--- a/src/artery/application/ItsG5Service.cc
+++ b/src/artery/application/ItsG5Service.cc
@@ -28,7 +28,7 @@ ItsG5Service::~ItsG5Service()
 {
 }
 
-void ItsG5Service::indicate(const vanetza::btp::DataIndication& ind, std::unique_ptr<vanetza::btp::UpPacket> raw_packet)
+void ItsG5Service::indicate(const vanetza::btp::DataIndication& ind, std::unique_ptr<UpPacket> raw_packet)
 {
 	using namespace vanetza;
 
@@ -72,7 +72,7 @@ void ItsG5Service::indicate(const vanetza::btp::DataIndication& ind, cPacket* pa
 
 void ItsG5Service::request(const vanetza::btp::DataRequestB& req, cPacket* packet)
 {
-	std::unique_ptr<vanetza::btp::DownPacket> buffer { new vanetza::btp::DownPacket() };
+	std::unique_ptr<DownPacket> buffer { new DownPacket() };
 	buffer->layer(vanetza::OsiLayer::Application) = std::move(packet);
 	ItsG5BaseService::request(req, std::move(buffer));
 }

--- a/src/artery/application/ItsG5Service.h
+++ b/src/artery/application/ItsG5Service.h
@@ -30,7 +30,7 @@ class ItsG5Service : public ItsG5BaseService
 	protected:
 		using ItsG5BaseService::indicate;
 		using ItsG5BaseService::request;
-		void indicate(const vanetza::btp::DataIndication&, std::unique_ptr<vanetza::btp::UpPacket>) override;
+		void indicate(const vanetza::btp::DataIndication&, std::unique_ptr<UpPacket>) override;
 		virtual void indicate(const vanetza::btp::DataIndication&, cPacket*);
 		void request(const vanetza::btp::DataRequestB&, cPacket*);
 };


### PR DESCRIPTION
When compiling under gcc vanetza::btp is not in the correct namespace. To fix this using is used.