### PR TITLE
Fix building with boost >= 1.64

### DIFF
--- a/src/artery/envmod/EnvironmentModelObject.cc
+++ b/src/artery/envmod/EnvironmentModelObject.cc
@@ -34,7 +34,7 @@ const std::vector<Position> squareAttachmentPoints = {
 
 const Position squareCentrePoint(-0.5, 0.0);
 
-#if BOOST_VERSION <= 106400
+#if BOOST_VERSION < 106400
 boost::geometry::strategy::transform::ublas_transformer<double, 2, 2>
 transformVehicle(double length, double width, const Position& pos, Angle alpha)
 {


### PR DESCRIPTION
ublas_transformer has been renamed to matrix_transformer in boost version 1.64, use ublas_transformer for boost < 1.64, not <= 1.64