### PR TITLE
traci: Add MultiTypeModuleMapper for configuring multiple vehicle types

### DIFF
--- a/scenarios/artery/vehicles.xml
+++ b/scenarios/artery/vehicles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<vehicles>
+    <vehicle type="artery.envmod.Car">
+        <penetration rate="0.5" />
+    </vehicle>
+    <vehicle type="artery.envmod.CarPlain">
+        <penetration rate="0.5" />
+    </vehicle>
+</vehicles>

--- a/src/traci/CMakeLists.txt
+++ b/src/traci/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     Core.cc
     ConnectLauncher.cc
     Listener.cc
+    MultiTypeModuleMapper.cc
     Position.cc
     PosixLauncher.cc
     sumo/foreign/tcpip/socket.cpp

--- a/src/traci/MultiTypeModuleMapper.cc
+++ b/src/traci/MultiTypeModuleMapper.cc
@@ -1,0 +1,70 @@
+#include "traci/MultiTypeModuleMapper.h"
+#include <omnetpp/ccomponenttype.h>
+#include <boost/lexical_cast.hpp>
+#include <boost/exception/diagnostic_information.hpp>
+
+namespace traci
+{
+
+Define_Module(MultiTypeModuleMapper)
+
+void MultiTypeModuleMapper::initialize()
+{
+	mRng = getRNG(0);
+
+	auto vehicleTypes =  par("vehicleTypes").xmlValue();
+	parseVehicleTypes(vehicleTypes);
+}
+
+void MultiTypeModuleMapper::parseVehicleTypes(omnetpp::cXMLElement* vehicleTypes)
+{
+	auto throwError = [](std::string msg, omnetpp::cXMLElement* node) {
+		std::ostringstream out;
+		out << node->getSourceLocation() << ": " << msg;
+		throw omnetpp::cRuntimeError(out.str().c_str());
+	};
+
+	double cdfValue = 0;
+	for (omnetpp::cXMLElement* vehicleNode: vehicleTypes->getChildrenByTagName("vehicle")) {
+		auto typeString = vehicleNode->getAttribute("type");
+		if (!typeString) {
+			throwError("missing 'type' attribute in 'vehicle' tag", vehicleNode);
+		}
+
+		auto type = omnetpp::cModuleType::get(typeString);
+
+		auto penetrationTag = vehicleNode->getFirstChildWithTag("penetration");
+		if (!penetrationTag) {
+			throwError("missing 'penetration' tag", vehicleNode);
+		}
+		auto rateAttribute = penetrationTag->getAttribute("rate");
+		if (!rateAttribute) {
+			throwError("missing 'rate' attribute in 'penetration' tag", penetrationTag);
+		}
+		double rate;
+		try {
+			rate = boost::lexical_cast<double>(rateAttribute);
+		} catch (boost::bad_lexical_cast& e) {
+			throwError("bad 'rate' attribute value: could not cast to double", penetrationTag);
+		}
+
+		auto vehicleType = std::make_tuple(type, rate);
+		mVehicleTypes.push_back(vehicleType);
+
+		cdfValue += rate;
+		mVehicleTypesCdfValues.push_back(cdfValue);
+	}
+}
+
+omnetpp::cModuleType* MultiTypeModuleMapper::vehicle(NodeManager& manager, const std::string& id)
+{
+	const double dice = omnetpp::uniform(mRng, 0.0, 1.0);
+	for (auto i = 0; i < mVehicleTypesCdfValues.size(); i++) {
+		if (dice <= mVehicleTypesCdfValues[i]) {
+			return std::get<0>(mVehicleTypes[i]);
+		}
+	}
+	throw omnetpp::cRuntimeError("Unable to equip vehicle");
+}
+
+} // namespace traci

--- a/src/traci/MultiTypeModuleMapper.h
+++ b/src/traci/MultiTypeModuleMapper.h
@@ -1,0 +1,35 @@
+#ifndef MULTITYPEMODULEMAPPER_H
+#define MULTITYPEMODULEMAPPER_H
+
+#include "traci/ModuleMapper.h"
+#include <omnetpp/csimplemodule.h>
+#include <omnetpp/cxmlelement.h>
+#include <omnetpp/crng.h>
+
+#include <vector>
+
+namespace traci
+{
+
+class MultiTypeModuleMapper : public ModuleMapper, public omnetpp::cSimpleModule
+{
+public:
+	void initialize() override;
+	omnetpp::cModuleType* vehicle(NodeManager&, const std::string&) override;
+
+private:
+	using VehicleType = std::tuple<omnetpp::cModuleType*, double>;
+	using VehicleTypes = std::vector<VehicleType>;
+
+	void parseVehicleTypes(omnetpp::cXMLElement*);
+
+	VehicleTypes mVehicleTypes;
+	std::vector<double> mVehicleTypesCdfValues;
+
+	omnetpp::cRNG* mRng;
+};
+
+} // namespace traci
+
+#endif /* MULTITYPEMODULEMAPPER_H */
+

--- a/src/traci/MultiTypeModuleMapper.ned
+++ b/src/traci/MultiTypeModuleMapper.ned
@@ -1,0 +1,8 @@
+package traci;
+
+simple MultiTypeModuleMapper like ModuleMapper
+{
+    parameters:
+        @class(traci::MultiTypeModuleMapper);
+        xml vehicleTypes;
+}


### PR DESCRIPTION
This allows simulating multiple differently equipped vehicle types in a single scenario.