### PR TITLE
WIP: Add envmod.PlainVehicle

### DIFF
--- a/scenarios/artery/omnetpp.ini
+++ b/scenarios/artery/omnetpp.ini
@@ -80,6 +80,14 @@ network = artery.envmod.World
 *.node[*].environmentModel.sensors = xmldoc("sensors.xml")
 
 
+[Config envmod_multiple_vehicle_types]
+extends = envmod
+# see above for configuration of mapper's random number generator (rng)
+seed-1-mt = ${seed=0, 23, 42, 1337, 0815, 4711}
+*.traci.mapper.typename = "traci.MultiTypeModuleMapper"
+*.traci.mapper.vehicleTypes = xmldoc("vehicles-envmod.xml")
+
+
 [Config inet_rsu]
 extends = inet
 *.numRoadSideUnits = 2

--- a/scenarios/artery/vehicles-envmod.xml
+++ b/scenarios/artery/vehicles-envmod.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<vehicles>
+    <vehicle type="artery.envmod.Car" rate="0.5" />
+    <vehicle type="artery.envmod.PlainVehicle" rate="0.5" />
+</vehicles>

--- a/src/artery/application/Middleware.cc
+++ b/src/artery/application/Middleware.cc
@@ -171,6 +171,7 @@ void Middleware::initializeMiddleware()
 
 void Middleware::initializeIdentity(Identity& id)
 {
+	id.component = getParentModule()->getId();
 	id.geonet = mGeoRouter->get_local_position_vector().gn_addr;
 }
 

--- a/src/artery/application/VehicleDataProvider.h
+++ b/src/artery/application/VehicleDataProvider.h
@@ -48,6 +48,7 @@ class VehicleDataProvider
 		void update(const traci::VehicleController*);
 		omnetpp::SimTime updated() const { return mLastUpdate; }
 
+		void set_station_id(uint32_t id) { mStationId = id; }
 		uint32_t station_id() const { return mStationId; }
 		const Position& position() const { return mPosition; }
 		vanetza::units::GeoAngle longitude() const { return mGeoPosition.longitude; } // positive for east

--- a/src/artery/application/VehicleMiddleware.cc
+++ b/src/artery/application/VehicleMiddleware.cc
@@ -39,7 +39,8 @@ void VehicleMiddleware::initializeIdentity(Identity& id)
 {
 	Middleware::initializeIdentity(id);
 	id.traci = mVehicleController->getVehicleId();
-	id.application = mVehicleDataProvider.station_id();
+	id.application = id.component;
+	mVehicleDataProvider.set_station_id(id.component);
 }
 
 void VehicleMiddleware::initializeManagementInformationBase(vanetza::geonet::MIB& mib)

--- a/src/artery/envmod/CMakeLists.txt
+++ b/src/artery/envmod/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_artery_feature(envmod
+    CarIdentityRegistrant.cc
     EnvironmentModelObject.cc
     GlobalEnvironmentModel.cc
     InterdistanceMatrix.cc

--- a/src/artery/envmod/CarIdentityRegistrant.cc
+++ b/src/artery/envmod/CarIdentityRegistrant.cc
@@ -1,0 +1,44 @@
+#include "artery/envmod/CarIdentityRegistrant.h"
+#include "artery/utility/IdentityRegistry.h"
+#include "artery/traci/MobilityBase.h"
+
+
+namespace artery
+{
+
+Define_Module(CarIdentityRegistrant)
+
+void CarIdentityRegistrant::initialize()
+{
+	initializeIdentity();
+	registerIdentity();
+}
+
+void CarIdentityRegistrant::initializeIdentity()
+{
+	auto parent = this->getParentModule();
+	auto mobility = dynamic_cast<MobilityBase*>(parent->getSubmodule("mobility", -1));
+	if (!mobility) {
+		throw omnetpp::cRuntimeError("no suitable mobility module found");
+	}
+	auto controller = mobility->getVehicleController();
+
+	auto traciId = controller->getVehicleId();
+	auto stationId = omnetpp::intuniform(getRNG(0), 0, 4294967295);
+
+	mIdentity.application = stationId;
+	mIdentity.traci = traciId;
+	mIdentity.geonet = vanetza::geonet::Address();
+}
+
+void CarIdentityRegistrant::registerIdentity()
+{
+	emit(artery::IdentityRegistry::updateSignal, &mIdentity);
+}
+
+void CarIdentityRegistrant::finish()
+{
+	emit(artery::IdentityRegistry::removeSignal, &mIdentity);
+}
+
+} // namespace artery

--- a/src/artery/envmod/CarIdentityRegistrant.cc
+++ b/src/artery/envmod/CarIdentityRegistrant.cc
@@ -16,7 +16,7 @@ void CarIdentityRegistrant::initialize()
 
 void CarIdentityRegistrant::initializeIdentity()
 {
-	auto parent = this->getParentModule();
+	auto parent = getParentModule();
 	auto mobility = dynamic_cast<MobilityBase*>(parent->getSubmodule("mobility", -1));
 	if (!mobility) {
 		throw omnetpp::cRuntimeError("no suitable mobility module found");
@@ -24,9 +24,10 @@ void CarIdentityRegistrant::initializeIdentity()
 	auto controller = mobility->getVehicleController();
 
 	auto traciId = controller->getVehicleId();
-	auto stationId = omnetpp::intuniform(getRNG(0), 0, 4294967295);
+	auto componentId = getParentModule()->getId();
 
-	mIdentity.application = stationId;
+	mIdentity.component = componentId;
+	mIdentity.application = componentId;
 	mIdentity.traci = traciId;
 	mIdentity.geonet = vanetza::geonet::Address();
 }

--- a/src/artery/envmod/CarIdentityRegistrant.h
+++ b/src/artery/envmod/CarIdentityRegistrant.h
@@ -1,0 +1,21 @@
+#include "artery/utility/Identity.h"
+#include <omnetpp/csimplemodule.h>
+
+
+namespace artery
+{
+
+class CarIdentityRegistrant : public omnetpp::cSimpleModule
+{
+	protected:
+		void initialize() override;
+		void finish() override;
+
+	private:
+		artery::Identity mIdentity;
+
+		void initializeIdentity();
+		void registerIdentity();
+};
+
+} // namespace artery

--- a/src/artery/envmod/CarIdentityRegistrant.ned
+++ b/src/artery/envmod/CarIdentityRegistrant.ned
@@ -1,0 +1,9 @@
+package artery.envmod;
+
+simple CarIdentityRegistrant
+{
+    parameters:
+        @class(CarIdentityRegistrant);
+        @signal[Identity.update](type=artery::Identity);
+        @signal[Identity.remove](type=artery::Identity);
+}

--- a/src/artery/envmod/PlainVehicle.ned
+++ b/src/artery/envmod/PlainVehicle.ned
@@ -1,21 +1,15 @@
 package artery.envmod;
 
-import inet.mobility.contract.IMobility;
+import artery.inet.PlainVehicle;
 import artery.envmod.CarIdentityRegistrant;
 
-module PlainVehicle
+module PlainVehicle extends artery.inet.PlainVehicle
 {
     parameters:
         @display("i=blocki/process;is=vs");
         @labels(node);
-        mobility.visualRepresentation = "^";
 
     submodules:
-        mobility: <default("artery.inet.Mobility")> like IMobility {
-            parameters:
-                @display("p=50,200");
-        }
-
         carIdentityRegistrant: CarIdentityRegistrant {
             parameters:
                 @display("p=53,300");

--- a/src/artery/envmod/PlainVehicle.ned
+++ b/src/artery/envmod/PlainVehicle.ned
@@ -1,0 +1,24 @@
+package artery.envmod;
+
+import inet.mobility.contract.IMobility;
+import artery.envmod.CarIdentityRegistrant;
+
+module PlainVehicle
+{
+    parameters:
+        @display("i=blocki/process;is=vs");
+        @labels(node);
+        mobility.visualRepresentation = "^";
+
+    submodules:
+        mobility: <default("artery.inet.Mobility")> like IMobility {
+            parameters:
+                @display("p=50,200");
+        }
+
+        carIdentityRegistrant: CarIdentityRegistrant {
+            parameters:
+                @display("p=53,300");
+        }
+
+}

--- a/src/artery/inet/Car.ned
+++ b/src/artery/inet/Car.ned
@@ -7,7 +7,7 @@ import inet.linklayer.contract.IWirelessNic;
 import inet.mobility.contract.IMobility;
 import inet.networklayer.common.InterfaceTable;
 
-module Car extends PlainVehicle like INetworkNode
+module Car like INetworkNode
 {
     parameters:
         @display("i=block/wrxtx;is=vs");
@@ -17,6 +17,7 @@ module Car extends PlainVehicle like INetworkNode
         @statistic[posY](source="yCoord(mobilityPos(mobilityStateChanged))"; record=vector?);
         int numRadios = default(1);
         *.interfaceTableModule = default(absPath(".interfaceTable"));
+        mobility.visualRepresentation = "^";
 
     gates:
         input radioIn[numRadios] @directIn;
@@ -45,6 +46,11 @@ module Car extends PlainVehicle like INetworkNode
                 @display("p=250,200");
                 radioDriverModule = ".radioDriver[0]";
                 mobilityModule = ".mobility";
+        }
+
+        mobility: <default("artery.inet.Mobility")> like IMobility {
+            parameters:
+                @display("p=50,200");
         }
 
     connections:

--- a/src/artery/utility/Identity.h
+++ b/src/artery/utility/Identity.h
@@ -19,6 +19,7 @@ namespace artery
 class Identity : public omnetpp::cObject
 {
 public:
+    int component; /*< OMNet++ component id */
     std::string traci; /*< Vehicle ID used by TraCI protocol */
     uint32_t application; /*< ETSI station ID */
     vanetza::geonet::Address geonet; /*< GeoNetworking layer */


### PR DESCRIPTION
Adds a 'plain' car without V2X for envmod.
This means no Middleware, so the car needs to register itself in the IdentityRegistry to allow other vehicles to reference it.