### PR TITLE
Use python2 for Veins' configure script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PYTHON ?= python
+PYTHON2 ?= python2
 INET_DIR = extern/inet
 INET_DISABLE_FEATURES ?= packetdrill
 SIMULTE_DIR = extern/simulte
@@ -31,7 +32,7 @@ simulte: $(SIMULTE_DIR)/src/Makefile
 	$(MAKE) -C $(SIMULTE_DIR)/src
 
 $(VEINS_DIR)/src/Makefile: $(VEINS_DIR)/configure
-	cd $(VEINS_DIR); $(PYTHON) configure
+	cd $(VEINS_DIR); $(PYTHON2) configure
 	$(MAKE) -C $(VEINS_DIR)/src depend
 
 veins: $(VEINS_DIR)/src/Makefile


### PR DESCRIPTION
Veins needs python2 for its configure script:
https://github.com/sommer/veins/blob/839ab632cb525e046921b2798cbb6e9c9963c85a/configure#L1

This is rather cosmetic, only one python3-incompatible line in configure right now:
https://github.com/sommer/veins/blob/17136a30ad657dec039fc8aa466de2ba052e5ecb/configure#L46