### PR TITLE
Allow for multiple filters in a `filters` group and add a FilterRule for station module type name pattern

### DIFF
--- a/scenarios/artery/omnetpp.ini
+++ b/scenarios/artery/omnetpp.ini
@@ -72,6 +72,7 @@ extends = inet
 seed-1-mt = ${seed=0, 23, 42, 1337, 0815, 4711}
 *.traci.mapper.typename = "traci.MultiTypeModuleMapper"
 *.traci.mapper.vehicleTypes = xmldoc("vehicles.xml")
+*.node[*].middleware.services = xmldoc("services-type-filter.xml")
 
 
 [Config envmod]

--- a/scenarios/artery/services-type-filter.xml
+++ b/scenarios/artery/services-type-filter.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<services>
+	<service type="artery.application.CaService">
+		<listener port="2001" />
+		<filters>
+			<type pattern="artery\.inet\.Car.*" rate="0.5"/>
+			<type pattern="artery\.inet\.OtherCar.*" rate="0.5"/>
+		</filters>
+	</service>
+	<service type="artery.application.ExampleService">
+		<listener port="4711" />
+		<filters>
+			<name pattern="flow0\.1.*" />
+			<penetration rate="0.5" />
+		</filters>
+	</service>
+</services>

--- a/src/artery/utility/FilterRules.cc
+++ b/src/artery/utility/FilterRules.cc
@@ -63,9 +63,11 @@ bool FilterRules::applyFilterConfig(const omnetpp::cXMLElement& filter_cfg)
 {
     std::list<Filter> filters;
 
-    cXMLElement* name_filter_cfg = filter_cfg.getFirstChildWithTag("name");
-    if (name_filter_cfg) {
-        filters.emplace_back(createFilterNamePattern(*name_filter_cfg));
+    cXMLElementList name_filter_cfg_list = filter_cfg.getChildrenByTagName("name");
+    if (name_filter_cfg_list.size() > 0) {
+        for (cXMLElement* cfg : name_filter_cfg_list) {
+            filters.emplace_back(createFilterNamePattern(*cfg));
+        }
     }
 
     cXMLElement* penetration_filter_cfg = filter_cfg.getFirstChildWithTag("penetration");

--- a/src/artery/utility/FilterRules.cc
+++ b/src/artery/utility/FilterRules.cc
@@ -7,6 +7,7 @@
 #include "artery/utility/Identity.h"
 #include "artery/utility/FilterRules.h"
 #include <boost/lexical_cast.hpp>
+#include <omnetpp/ccomponenttype.h>
 #include <omnetpp/cexception.h>
 #include <omnetpp/cxmlelement.h>
 #include <omnetpp/distrib.h>
@@ -59,6 +60,34 @@ auto FilterRules::createFilterPenetrationRate(const cXMLElement& penetration_fil
     return penetration_filter;
 }
 
+auto FilterRules::createFilterTypePattern(const cXMLElement& type_filter_cfg) const -> Filter
+{
+    const char* type_pattern = type_filter_cfg.getAttribute("pattern");
+    const char* type_match = type_filter_cfg.getAttribute("match");
+    bool inverse = type_match && std::strcmp(type_match, "inverse") == 0;
+    if (!type_pattern) {
+        throw cRuntimeError("Required pattern attribute is missing for type filter");
+    }
+
+    const char* type_rate_str = type_filter_cfg.getAttribute("rate");
+
+    double type_rate = 1.0;
+    if (type_rate_str) {
+        type_rate = boost::lexical_cast<double>(type_rate_str);
+    }
+    if (type_rate > 1.0 || type_rate < 0.0) {
+        throw cRuntimeError("Type penetration rate is out of range [0.0, 1.0]");
+    }
+
+    std::regex type_regex(type_pattern);
+    Filter type_filter = [this, type_rate, type_regex, inverse]() {
+        auto rate_predicate = type_rate >= uniform(mRNG, 0.0, 1.0);
+        auto type = mIdentity.host->getModuleType()->getFullName();
+        return (std::regex_match(type, type_regex) && rate_predicate) ^ inverse;
+    };
+    return type_filter;
+}
+
 bool FilterRules::applyFilterConfig(const omnetpp::cXMLElement& filter_cfg)
 {
     std::list<Filter> filters;
@@ -73,6 +102,13 @@ bool FilterRules::applyFilterConfig(const omnetpp::cXMLElement& filter_cfg)
     cXMLElement* penetration_filter_cfg = filter_cfg.getFirstChildWithTag("penetration");
     if (penetration_filter_cfg) {
         filters.emplace_back(createFilterPenetrationRate(*penetration_filter_cfg));
+    }
+
+    cXMLElementList type_filter_cfg_list = filter_cfg.getChildrenByTagName("type");
+    if (type_filter_cfg_list.size() > 0) {
+        for (cXMLElement* cfg : type_filter_cfg_list) {
+            filters.emplace_back(createFilterTypePattern(*cfg));
+        }
     }
 
     bool applicable = true;

--- a/src/artery/utility/FilterRules.h
+++ b/src/artery/utility/FilterRules.h
@@ -32,6 +32,7 @@ public:
 protected:
     Filter createFilterNamePattern(const omnetpp::cXMLElement&) const;
     Filter createFilterPenetrationRate(const omnetpp::cXMLElement&) const;
+    Filter createFilterTypePattern(const omnetpp::cXMLElement&) const;
 
 private:
     omnetpp::cRNG* mRNG;


### PR DESCRIPTION
This allows pattern matching on the station module type in FilterRule.