### PR TITLE
Expose another SUMO position conversion via the TraCI API: geo position (lon/lat) -> 2D

### DIFF
--- a/src/traci/API.cc
+++ b/src/traci/API.cc
@@ -49,6 +49,27 @@ TraCIGeoPosition API::convertGeo(const TraCIPosition& pos) const
     return geo;
 }
 
+TraCIPosition API::convert2D( TraCIGeoPosition const &pos ) const {
+    using namespace constants;
+
+    tcpip::Storage addParams;
+    addParams.writeUnsignedByte(TYPE_COMPOUND);
+    addParams.writeInt(2);
+    addParams.writeUnsignedByte(POSITION_LON_LAT);
+    addParams.writeDouble(pos.longitude);
+    addParams.writeDouble(pos.latitude);
+    addParams.writeUnsignedByte(TYPE_UBYTE);
+    addParams.writeUnsignedByte(POSITION_2D);
+    send_commandGetVariable(CMD_GET_SIM_VARIABLE, POSITION_CONVERSION, "", &addParams);
+
+    tcpip::Storage inMsg;
+    processGET(inMsg, CMD_GET_SIM_VARIABLE, POSITION_2D);
+    TraCIPosition xyPos;
+    xyPos.x = inMsg.readDouble();
+    xyPos.y = inMsg.readDouble();
+    return xyPos;
+}
+
 void API::connect(const ServerEndpoint& endpoint)
 {
     const unsigned max_tries = endpoint.retry ? 10 : 0;

--- a/src/traci/API.h
+++ b/src/traci/API.h
@@ -20,6 +20,7 @@ public:
     using Version = std::pair<int, std::string>;
     Version getVersion() const;
     TraCIGeoPosition convertGeo(const TraCIPosition&) const;
+    TraCIPosition convert2D( TraCIGeoPosition const &pos ) const;
 
     void connect(const ServerEndpoint&);
 };

--- a/src/traci/LiteAPI.h
+++ b/src/traci/LiteAPI.h
@@ -12,6 +12,7 @@ public:
     LiteAPI(API& api) : m_api(api) {}
 
     TraCIGeoPosition convertGeo(const TraCIPosition& pos) const { return m_api.convertGeo(pos); }
+    TraCIPosition convert2D(const TraCIGeoPosition& pos) const { return m_api.convert2D(pos); }
 
     API::EdgeScope& edge() { return m_api.edge; }
     const API::EdgeScope& edge() const { return m_api.edge; }


### PR DESCRIPTION
This exposes another conversion by SUMO via the TraCI protocol: Conversion of a geo position to (SUMO) 2D coordinates.

This conversion is not yet used by any code in artery/master, however we need this conversion in our code for which further pull requests will follow soon.

Rationale: When dealing with coordinates in ITS-G5 messages, this can be achieved by handling all coordinates as geo coordinates. Another way, and the easier one in our use case, is handling all coordinates in x/y coordinates. For this we need this conversion. After a traci::position_cast(...) to the SUMO network boundary these x/y coordinates (converted from geo coords) are equivalent to those presented by VehicleController::getPosition().

As usual, am happy to address any issues, comments, etc.