### PR TITLE
LocalEnvironmentModel: mark signal reception interface method as overiding the parent member function

### DIFF
--- a/src/artery/envmod/LocalEnvironmentModel.h
+++ b/src/artery/envmod/LocalEnvironmentModel.h
@@ -78,7 +78,7 @@ public:
     int numInitStages() const override;
     void initialize(int stage) override;
     void finish() override;
-    void receiveSignal(cComponent*, omnetpp::simsignal_t, cObject*, cObject*);
+    void receiveSignal(cComponent*, omnetpp::simsignal_t, cObject*, cObject*) override;
 
     /**
      * Updates the local environment model


### PR DESCRIPTION
When compiling with clang I get the following warning:
`In file included from /home/artery/artery/src/artery/envmod/sensor/BaseSensor.cc:8:
/home/artery/artery/src/artery/envmod/LocalEnvironmentModel.h:81:10: warning:`  
`'receiveSignal' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]`  
`void receiveSignal(cComponent*, omnetpp::simsignal_t, cObject*, cObject*);`