### PR TITLE
Fixing double initialization of ItsG5Services with multiple stages

### DIFF
--- a/src/artery/application/Middleware.cc
+++ b/src/artery/application/Middleware.cc
@@ -261,7 +261,11 @@ void Middleware::initializeServices()
 		if (service_applicable) {
 			const char* service_name = service_cfg->getAttribute("name") ?
 				service_cfg->getAttribute("name") : module_type->getName();
-			cModule* module = module_type->createScheduleInit(service_name, this);
+			cModule *module = module_type->create(service_name, this);
+			module->finalizeParameters();
+			module->buildInside();
+			module->scheduleStart(getSimulation()->getSimTime());
+			module->callInitialize(0);
 			ItsG5BaseService* service = dynamic_cast<ItsG5BaseService*>(module);
 
 			if (service) {


### PR DESCRIPTION
Calling `createScheduleInit()` will initialize all stages of a module.
This is done in stage 1 of `Middleware::initialize(int stage)`.

If a services has 2 or more stages, all stages greater or equal to 1
will be initialized twice, as later stages are handled by OMNeT again.