### PR TITLE
Fix module context switching in AccessInterface

### DIFF
--- a/src/artery/networking/AccessInterface.cc
+++ b/src/artery/networking/AccessInterface.cc
@@ -22,6 +22,7 @@ void AccessInterface::request(const DataRequest& request, std::unique_ptr<ChunkP
 {
     // Enter_Method on steroids...
     omnetpp::cMethodCallContextSwitcher ctx(mModuleOut);
+    ctx.methodCall("request");
 
     GeoNetPacket* gn = new GeoNetPacket("GeoNet packet");
     gn->setPayload(std::move(payload));


### PR DESCRIPTION
Fix macro expansion in `AccessInterface`, see definition of `Enter_Method` in `omnetpp/simutil.h`

Fixes:
```
ASSERT: Condition 'currentMethodCall' does not hold in function 'methodcallEnd' at messageanimator.cc:128
-- in module (artery::Router) World.node[0].vanetza[0].router (id=144), at t=0.259284461639s, event #6
```
