### PR TITLE
DccEntityBase: call ChannelProbeProcessor for CBR reporting

### DIFF
--- a/src/artery/networking/DccEntityBase.cc
+++ b/src/artery/networking/DccEntityBase.cc
@@ -96,7 +96,7 @@ void DccEntityBase::initializeChannelProbeProcessor(const std::string& name)
 
 void DccEntityBase::reportLocalChannelLoad(vanetza::dcc::ChannelLoad cbr)
 {
-    onLocalCbr(cbr);
+    mCbrProcessor->indicate(cbr);
 }
 
 void DccEntityBase::onLocalCbr(vanetza::dcc::ChannelLoad cbr)


### PR DESCRIPTION
Call `ChannelProbeProcessor::indicate` for CBR reporting.

It seems `SmoothingChannelProbeProcessor::indicate` is never called when the CBR is updated, so `SmoothingChannelProbeProcessor::channel_load` always reports 0.