### PR TITLE
Fix checkHeadingDelta for the cases where the heading of a vehicle is…

### DIFF
--- a/src/artery/application/CaService.cc
+++ b/src/artery/application/CaService.cc
@@ -26,6 +26,8 @@ static const simsignal_t scSignalCamReceived = cComponent::registerSignal("CamRe
 static const simsignal_t scSignalCamSent = cComponent::registerSignal("CamSent");
 static const auto scLowFrequencyContainerInterval = std::chrono::milliseconds(500);
 
+static const vanetza::units::Angle MAXANGLE(360.0 * boost::units::degree::degree);
+
 template<typename T, typename U>
 long round(const boost::units::quantity<T>& q, const U& u)
 {
@@ -114,7 +116,13 @@ void CaService::checkTriggeringConditions(const SimTime& T_now)
 
 bool CaService::checkHeadingDelta() const
 {
-	return abs(mLastCamHeading - mVehicleDataProvider->heading()) > mHeadingDelta;
+    if(mLastCamHeading >= MAXANGLE - mHeadingDelta && mVehicleDataProvider->heading() <= mHeadingDelta)
+        return abs(mLastCamHeading - mVehicleDataProvider->heading() - MAXANGLE) > mHeadingDelta;
+
+    if(mLastCamHeading <= mHeadingDelta && mVehicleDataProvider->heading() >= MAXANGLE - mHeadingDelta)
+        return abs(mLastCamHeading - mVehicleDataProvider->heading() + MAXANGLE) > mHeadingDelta;
+
+    return abs(mLastCamHeading - mVehicleDataProvider->heading()) > mHeadingDelta;
 }
 
 bool CaService::checkPositionDelta() const

--- a/src/artery/application/CaService.cc
+++ b/src/artery/application/CaService.cc
@@ -10,6 +10,7 @@
 #include <vanetza/btp/ports.hpp>
 #include <vanetza/dcc/transmission.hpp>
 #include <vanetza/dcc/transmit_rate_control.hpp>
+#include <vanetza/facilities/cam_functions.hpp>
 #include <chrono>
 
 namespace artery
@@ -26,7 +27,6 @@ static const simsignal_t scSignalCamReceived = cComponent::registerSignal("CamRe
 static const simsignal_t scSignalCamSent = cComponent::registerSignal("CamSent");
 static const auto scLowFrequencyContainerInterval = std::chrono::milliseconds(500);
 
-static const vanetza::units::Angle MAXANGLE(360.0 * boost::units::degree::degree);
 
 template<typename T, typename U>
 long round(const boost::units::quantity<T>& q, const U& u)
@@ -116,13 +116,7 @@ void CaService::checkTriggeringConditions(const SimTime& T_now)
 
 bool CaService::checkHeadingDelta() const
 {
-    if(mLastCamHeading >= MAXANGLE - mHeadingDelta && mVehicleDataProvider->heading() <= mHeadingDelta)
-        return abs(mLastCamHeading - mVehicleDataProvider->heading() - MAXANGLE) > mHeadingDelta;
-
-    if(mLastCamHeading <= mHeadingDelta && mVehicleDataProvider->heading() >= MAXANGLE - mHeadingDelta)
-        return abs(mLastCamHeading - mVehicleDataProvider->heading() + MAXANGLE) > mHeadingDelta;
-
-    return abs(mLastCamHeading - mVehicleDataProvider->heading()) > mHeadingDelta;
+	return !vanetza::facilities::similar_heading(mLastCamHeading, mVehicleDataProvider->heading(), mHeadingDelta);
 }
 
 bool CaService::checkPositionDelta() const


### PR DESCRIPTION
Problem: the function checkHeadingDelta, in the CaService.cc file, does not work properly in certain cases where the heading of a vehicle is around 0°.
Example:
mLastCamHeading = 1°
mVehicleDataProvider->heading() = 359°
checkHeadingDelta() will return true (359 - 1 = 358) while the difference is only of 2°.

Proposed change: modify the function checkHeadingDelta to return false in cases similar to the aforementioned example.