### PR TITLE
Improvements to channelBusyRatio calculation

### DIFF
--- a/src/artery/inet/VanetRx.h
+++ b/src/artery/inet/VanetRx.h
@@ -2,7 +2,6 @@
 #define ARTERY_VANETRX_H_KTVCYSUX
 
 #include "inet/linklayer/ieee80211/mac/Rx.h"
-#include <boost/circular_buffer.hpp>
 
 namespace artery
 {
@@ -25,8 +24,9 @@ private:
     omnetpp::simtime_t channelReportInterval;
     omnetpp::cMessage* channelReportTrigger;
     omnetpp::simtime_t channelLoadLastUpdate;
-    boost::circular_buffer<bool> channelLoadSamples;
+    std::list<std::tuple<uint,bool>> channelLoadSamples;
     double channelBusyRatio;
+    const uint cbrInterval = 12500;
 };
 
 } // namespace artery


### PR DESCRIPTION
Hi Raphael,

I did some performance profiling of artery using vallgrind and KCachegrind, running the car2car-grid scenario. I uploaded my recordings [here](https://github.com/riebl/artery/files/3305978/improved_channelBusyRatio.zip).

 
It can be noticed that https://github.com/riebl/artery/blob/2022b620ca949e654d3fd1c3c4cbe93ab9d9f302/src/artery/inet/VanetRx.cc#L60 and https://github.com/riebl/artery/blob/2022b620ca949e654d3fd1c3c4cbe93ab9d9f302/src/artery/inet/VanetRx.cc#L47 are quite costly.
This can be seen when opening `callgrind.out.release_channelBusyRatio_2022b62` form the attached archive with KCachegrind.


The issue stems from using a `boost::circular_buffer` with a lot of elements for the calculation `channelBusyRatio`.

I replaced the circular buffer `channelLoadSamples`, which previously stored the medium state for each symbol as a bool, with a list of tuples consisting of the number of symbols and the medium state for this time period.
This solution is not as elegant and intuitive as your circular buffer implementation, but improves the performance quite a bit (see `callgrind.out.release_channelBusyRatio_improved` in comparison).

For validation of the new implementation I recorded the the `ChannelLoad` signal by `VanetRx` for each implementation. The results are in the archive as well  (`elease_channelBusyRatio_2022b62_cam_fixed-#0.vec` and `release_channelBusyRatio_improved_cam_fixed-#0.vec`).
