### PR TITLE
Regions of Interest (RoI) for Scenarios

### DIFF
--- a/scenarios/artery/omnetpp.ini
+++ b/scenarios/artery/omnetpp.ini
@@ -136,3 +136,10 @@ description = "insert a bulk of vehicles with individual delays"
 extends = inet
 *.traci.core.startTime = 120 s
 *.traci.nodes.typename = "InsertionDelayNodeManager"
+
+
+[Config region_of_interest_vehicle_insertion]
+description = "Only manage vehicles within defined Regions of Interest (ROI)"
+extends = inet
+*.traci.nodes.typename = "RegionOfInterestNodeManager"
+*.traci.nodes.regionsOfInterest = xmldoc("regions_of_interest.xml")

--- a/src/traci/BasicNodeManager.cc
+++ b/src/traci/BasicNodeManager.cc
@@ -80,6 +80,18 @@ void BasicNodeManager::traciInit()
 
 void BasicNodeManager::traciStep()
 {
+    processVehiclesFromSimCache();
+    emit(updateNodeSignal, getNumberOfNodes());
+}
+
+void BasicNodeManager::traciClose()
+{
+    for (unsigned i = m_nodes.size(); i > 0; --i) {
+        removeNodeModule(m_nodes.begin()->first);
+    }
+}
+
+void BasicNodeManager::processVehiclesFromSimCache() {
     auto sim_cache = m_subscriptions->getSimulationCache();
     ASSERT(checkTimeSync(*sim_cache, omnetpp::simTime()));
 
@@ -107,15 +119,6 @@ void BasicNodeManager::traciStep()
         const std::string& id = vehicle.first;
         VehicleSink* sink = vehicle.second;
         updateVehicle(id, sink);
-    }
-
-    emit(updateNodeSignal, getNumberOfNodes());
-}
-
-void BasicNodeManager::traciClose()
-{
-    for (unsigned i = m_nodes.size(); i > 0; --i) {
-        removeNodeModule(m_nodes.begin()->first);
     }
 }
 

--- a/src/traci/BasicNodeManager.h
+++ b/src/traci/BasicNodeManager.h
@@ -33,6 +33,8 @@ public:
     static const omnetpp::simsignal_t removeVehicleSignal;
 
     LiteAPI* getLiteAPI() override { return m_api; }
+    SubscriptionManager* getSubscriptions() {return m_subscriptions; }
+    std::map<std::string, VehicleSink*>& getVehicleMap() { return m_vehicles; }
     std::size_t getNumberOfNodes() const override;
 
     /**
@@ -65,11 +67,13 @@ protected:
     virtual VehicleSink* getVehicleSink(omnetpp::cModule*);
     virtual VehicleSink* getVehicleSink(const std::string&);
 
-private:
+    void processVehiclesFromSimCache();
+
     void traciInit() override;
     void traciStep() override;
     void traciClose() override;
 
+private:
     LiteAPI* m_api;
     ModuleMapper* m_mapper;
     Boundary m_boundary;

--- a/src/traci/CMakeLists.txt
+++ b/src/traci/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCES
     MultiTypeModuleMapper.cc
     Position.cc
     PosixLauncher.cc
+    RegionOfInterestNodeManager.cc
     TestbedModuleMapper.cc
     TestbedNodeManager.cc
     ValueUtils.cc

--- a/src/traci/RegionOfInterestNodeManager.cc
+++ b/src/traci/RegionOfInterestNodeManager.cc
@@ -1,0 +1,179 @@
+/*
+ * Artery V2X Simulation Framework
+ * Copyright 2019 Alexander Willecke, Raphael Riebl
+ * Licensed under GPLv2, see COPYING file for detailed license and warranty terms.
+ */
+
+#include "traci/RegionOfInterestNodeManager.h"
+
+#include <omnetpp/cxmlelement.h>
+
+using namespace omnetpp;
+
+namespace traci
+{
+
+Define_Module(RegionOfInterestNodeManager)
+
+
+void RegionOfInterestNodeManager::initialize()
+{
+    BasicNodeManager::initialize();
+
+    cXMLElement* regions = par("regionsOfInterest").xmlValue();
+    for (cXMLElement* region : regions->getChildren()) {
+        if (!strcmp(region->getTagName(), "polygon")) {
+            /* create new polygon */
+            model::polygon<model::d2::point_xy<double>> poly;
+
+            for (cXMLElement* point : region->getChildren()) {
+                if (!strcmp(point->getTagName(),"point")) {
+                    /* iterate points in polygon */
+                    double x = boost::lexical_cast<double>(point->getAttribute("x"));
+                    double y = boost::lexical_cast<double>(point->getAttribute("y"));
+
+                    append(poly, boost::make_tuple(x, y));
+                }
+            }
+            /* append polygon list of polygons */
+            m_regions.push_back(model::polygon<model::d2::point_xy<double>> (poly));
+        }
+    }
+}
+
+void RegionOfInterestNodeManager::traciInit()
+{
+    BasicNodeManager::traciInit();
+
+    /* validate regions */
+    Boundary scenario_boundary = Boundary { BasicNodeManager::getLiteAPI()->simulation().getNetBoundary() };
+
+    model::polygon<model::d2::point_xy<double>> boundary;
+    append(boundary, boost::make_tuple(scenario_boundary.lowerLeftPosition().x, scenario_boundary.lowerLeftPosition().y));
+    append(boundary, boost::make_tuple(scenario_boundary.lowerLeftPosition().x, scenario_boundary.upperRightPosition().y));
+    append(boundary, boost::make_tuple(scenario_boundary.upperRightPosition().x, scenario_boundary.upperRightPosition().y));
+    append(boundary, boost::make_tuple(scenario_boundary.upperRightPosition().x, scenario_boundary.lowerLeftPosition().y));
+
+    for (auto &region: m_regions) {
+        if (!within(region, boundary)) {
+            EV_WARN << "Regions are out of scenario boundary!" << endl;
+        }
+    }
+    EV_INFO << "Added " << m_regions.size() << " Regions of Interest to simulation" << endl;
+}
+
+
+void RegionOfInterestNodeManager::traciStep()
+{
+    processVehiclesFromSimCache();
+    checkRoI();
+    emit(updateNodeSignal, getNumberOfNodes());
+}
+
+
+
+void RegionOfInterestNodeManager::addVehicle(const std::string& id)
+{
+    if (m_regions.size() == 0) {
+        BasicNodeManager::addVehicle(id);
+        return;
+    }
+
+    auto vehicle = BasicNodeManager::getSubscriptions()->getVehicleCache(id);
+
+    /* get vehicle position */
+    const TraCIPosition& tmp = vehicle->get<libsumo::VAR_POSITION>();
+    boost::tuple<double, double> vehicle_pos = boost::make_tuple(tmp.x,tmp.y);
+
+    for (auto &region: m_regions) {
+        /* check if vehicle is in Region of Interest */
+        if (within(vehicle_pos, region)) {
+            /* vehicle was in region and NOT in vehicle list */
+            EV_DEBUG << "Vehicle " << id << " is added: departed within a region" << endl;
+            BasicNodeManager::addVehicle(id);
+            return;
+        }
+    }
+    EV_DEBUG << "Vehicle " << id << " departed: departed outside a region of interest" << endl;
+}
+
+void RegionOfInterestNodeManager::removeVehicle(const std::string& id)
+{
+    if (m_regions.size() == 0) {
+        BasicNodeManager::removeVehicle(id);
+        return;
+    }
+
+    auto vehicle = BasicNodeManager::getSubscriptions()->getVehicleCache(id);
+
+    /* get vehicle position */
+    const TraCIPosition& tmp = vehicle->get<libsumo::VAR_POSITION>();
+    boost::tuple<double, double> vehicle_pos = boost::make_tuple(tmp.x,tmp.y);
+
+    for (auto region: m_regions) {
+        /* check if vehicle is in RoI */
+        if (within(vehicle_pos, region)) {
+            /* vehicle was in region and in vehicle list */
+            if (getVehicleMap().find(id) != getVehicleMap().end()) {
+                EV_DEBUG << "Vehicle " << id << " is removed: arrived inside RoI" << endl;
+                BasicNodeManager::removeVehicle(id);
+            }
+        }
+    }
+}
+
+void RegionOfInterestNodeManager::updateVehicle(const std::string& id, VehicleSink* sink)
+{
+    if (m_regions.size() == 0) {
+        BasicNodeManager::updateVehicle(id, sink);
+        return;
+    }
+
+    auto vehicle = BasicNodeManager::getSubscriptions()->getVehicleCache(id);
+
+    /* get vehicle position */
+    const TraCIPosition& tmp = vehicle->get<libsumo::VAR_POSITION>();
+    boost::tuple<double, double> vehicle_pos = boost::make_tuple(tmp.x,tmp.y);
+
+    for (auto region: m_regions) {
+        /* check if vehicle is in Region of Interest */
+        if (within(vehicle_pos, region)) {
+            /* vehicle is known and in RoI */
+            BasicNodeManager::updateVehicle(id, sink);
+            return;
+        }
+    }
+
+    /* known vehicle left Region of Interest */
+    EV_DEBUG << "Vehicle " << id << " was removed: left RoI" << endl;
+    BasicNodeManager::removeVehicle(id);
+}
+
+void RegionOfInterestNodeManager::checkRoI()
+{
+    if (m_regions.size() > 0) {
+        auto &current_vehicles = BasicNodeManager::getSubscriptions()->getSubscribedVehicles();
+
+        for (const auto& id : current_vehicles) {
+            /* iterate all known vehicles */
+            if (getVehicleMap().find(id) == getVehicleMap().end()) {
+                /* vehicle is not managed */
+                auto vehicle = BasicNodeManager::getSubscriptions()->getVehicleCache(id);
+
+                /* get vehicle position */
+                const TraCIPosition& tmp = vehicle->get<libsumo::VAR_POSITION>();
+                boost::tuple<double, double> vehicle_pos = boost::make_tuple(tmp.x,tmp.y);
+
+                for (auto region: m_regions) {
+                    /* check if vehicle is in Region of Interest */
+                    if (within(vehicle_pos, region)) {
+                        EV_DEBUG << "Vehicle " << id << " is added: entered RoI" << endl;
+                        BasicNodeManager::addVehicle(id);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+} // namespace traci

--- a/src/traci/RegionOfInterestNodeManager.h
+++ b/src/traci/RegionOfInterestNodeManager.h
@@ -1,0 +1,48 @@
+/*
+ * Artery V2X Simulation Framework
+ * Copyright 2019 Alexander Willecke, Raphael Riebl
+ * Licensed under GPLv2, see COPYING file for detailed license and warranty terms.
+ */
+
+#ifndef REGIONOFINTERESTNODEMANAGER_H_AGMBROIE
+#define REGIONOFINTERESTNODEMANAGER_H_AGMBROIE
+
+#include "traci/BasicNodeManager.h"
+
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/polygon.hpp>
+#include <boost/geometry/geometries/adapted/boost_tuple.hpp>
+
+#include "traci/VariableCache.h"
+
+BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
+
+using namespace boost::geometry;
+
+namespace traci
+{
+
+class RegionOfInterestNodeManager : public BasicNodeManager
+{
+
+protected:
+    void initialize() override;
+
+    void addVehicle(const std::string& id);
+    void removeVehicle(const std::string& id);
+    void updateVehicle(const std::string& id, VehicleSink* sink);
+    void checkRoI();
+
+    void traciInit() override;
+    void traciStep() override;
+
+private:
+    // std::map<std::string, VehicleSink*> m_vehicles;
+    std::list< model::polygon<model::d2::point_xy<double>> > m_regions;
+};
+
+} // namespace traci
+
+#endif /* REGIONOFINTERESTNODEMANAGER_H_AGMBROIE */
+

--- a/src/traci/RegionOfInterestNodeManager.ned
+++ b/src/traci/RegionOfInterestNodeManager.ned
@@ -1,0 +1,13 @@
+package traci;
+
+//
+// Specialised node manager which will only create modules for 
+// SUMO vehicles if in a region of interest.
+// This is useful when running large scenarios
+//
+simple RegionOfInterestNodeManager extends BasicNodeManager
+{
+    parameters:
+        @class(traci::RegionOfInterestNodeManager);
+        xml regionsOfInterest = default(xml("<regions />"));
+}


### PR DESCRIPTION
With this branch Artery can be configured to only manage vehicles in Regions of Interest (RoI) of a scenario. This can be useful when simulating large SUMO scenarios where only certain regions are of interest (e.g junctions, crosswalks, ...).

RoIs can be defined with a XML structure, containing polygons, defined by points using SUMO coordinates. The BasicNodeManager will consider these RoIs when adding, removing or updating vehicles.

In this branch, Artery's example scenario contains two RoIs (vehicle spawn and center junction) to show the usage of the feature.