### PR TITLE
traci: Fix rotaion in TraCI angle_cast

### DIFF
--- a/src/traci/Angle.cc
+++ b/src/traci/Angle.cc
@@ -10,7 +10,7 @@ namespace traci
 artery::Angle angle_cast(TraCIAngle traci)
 {
     // change orientation and align "neutral" angle to east
-    double opp = 90.0 - traci.degree;
+    double opp = traci.degree - 90.0;
     // convert to radian
     opp *= pi / 180.0;
 


### PR DESCRIPTION
angle_cast from TraCIAngle to artery::Angle rotated the angle in the
wrong direction. The resulting angle was inverted before.

This becomes apparent when comparing the two casts since both rotate in the same direction when they should be the inverse of each other.