### PR TITLE
GlobalEnvMod: Added obstacle filter

### DIFF
--- a/src/artery/envmod/GlobalEnvironmentModel.h
+++ b/src/artery/envmod/GlobalEnvironmentModel.h
@@ -142,6 +142,7 @@ private:
     bool mTainted;
     omnetpp::cGroupFigure* mDrawObstacles = nullptr;
     omnetpp::cGroupFigure* mDrawVehicles = nullptr;
+    std::set<std::string> mFilterTypes;
 };
 
 } // namespace artery

--- a/src/artery/envmod/GlobalEnvironmentModel.ned
+++ b/src/artery/envmod/GlobalEnvironmentModel.ned
@@ -22,4 +22,5 @@ simple GlobalEnvironmentModel
         string identityRegistryModule;
         bool drawObstacles = default(false);
         bool drawVehicles = default(false);
+        string filterTypes = default("building shop");
 }


### PR DESCRIPTION
Hi Raphael,

some scenarios might have some polygons, which are not a building, such as parks, district borders and such.
Therefore, it might be useful to apply a filter to the polygons that are loaded into EnvMod as obstacles.

Regards
Alexander