### PR TITLE
Sensors: Added doLineOfSightCheck as parameter

### DIFF
--- a/src/artery/envmod/sensor/FrontRadar.ned
+++ b/src/artery/envmod/sensor/FrontRadar.ned
@@ -12,4 +12,5 @@ simple FrontRadar like Radar
         double fovRange @unit(m) = default(80.0 m);
         double fovAngle = default(60.0); // degree
         int numSegments = default(10);
+        bool doLineOfSightCheck = default(true);
 }

--- a/src/artery/envmod/sensor/Radar.ned
+++ b/src/artery/envmod/sensor/Radar.ned
@@ -12,4 +12,5 @@ moduleinterface Radar
         double fovRange @unit(m);
         double fovAngle; // opening angle in degree
         int numSegments;
+        bool doLineOfSightCheck;
 }

--- a/src/artery/envmod/sensor/RadarSensor.cc
+++ b/src/artery/envmod/sensor/RadarSensor.cc
@@ -39,6 +39,7 @@ void RadarSensor::initialize()
     mRadarConfig.fieldOfView.range = par("fovRange").doubleValue() * boost::units::si::meters;
     mRadarConfig.fieldOfView.angle = par("fovAngle").doubleValue() * boost::units::degree::degrees;
     mRadarConfig.numSegments = par("numSegments");
+    mRadarConfig.doLineOfSightCheck = par("doLineOfSightCheck");
 }
 
 void RadarSensor::measurement()

--- a/src/artery/envmod/sensor/RearRadar.ned
+++ b/src/artery/envmod/sensor/RearRadar.ned
@@ -12,4 +12,5 @@ simple RearRadar like Radar
         double fovRange @unit(m) = default(80.0 m);
         double fovAngle = default(60.0); // degree
         int numSegments = default(10);
+        bool doLineOfSightCheck = default(true);
 }


### PR DESCRIPTION
Hi,

with this commit it is possible to disable the line of sight check for sensors using the simulation configuration.
This might be useful for evaluation purposes. 

Regards
Alexander