### PR TITLE
Generate station id only after module has been initialized

### DIFF
--- a/src/artery/application/VehicleDataProvider.cc
+++ b/src/artery/application/VehicleDataProvider.cc
@@ -188,4 +188,9 @@ auto VehicleDataProvider::getStationType() const -> StationType
 	return mStationType;
 }
 
+void VehicleDataProvider::setStationId(const uint32_t id)
+{
+	mStationId = id;
+}
+
 } // namespace artery

--- a/src/artery/application/VehicleDataProvider.h
+++ b/src/artery/application/VehicleDataProvider.h
@@ -64,6 +64,8 @@ class VehicleDataProvider
 		void setStationType(StationType);
 		StationType getStationType() const;
 
+		void setStationId(const uint32_t);
+
 	private:
 		typedef boost::units::quantity<boost::units::si::angular_acceleration> AngularAcceleration;
 		void calculateCurvature();

--- a/src/artery/application/VehicleMiddleware.cc
+++ b/src/artery/application/VehicleMiddleware.cc
@@ -18,7 +18,7 @@ namespace artery
 Define_Module(VehicleMiddleware)
 
 VehicleMiddleware::VehicleMiddleware() :
-    mVehicleDataProvider(Identity::randomStationId(getRNG(0)))
+    mVehicleDataProvider(0)
 {
 }
 
@@ -33,7 +33,8 @@ void VehicleMiddleware::initialize(int stage)
 
         Identity identity;
         identity.traci = mVehicleController->getVehicleId();
-        identity.application = mVehicleDataProvider.station_id();
+        identity.application = Identity::randomStationId(getRNG(0));
+        mVehicleDataProvider.setStationId(identity.application);
         emit(Identity::changeSignal, Identity::ChangeTraCI | Identity::ChangeStationId, &identity);
     }
 

--- a/src/artery/ots/GtuMiddleware.cc
+++ b/src/artery/ots/GtuMiddleware.cc
@@ -17,7 +17,7 @@ const simsignal_t gtuPositionChangedSignal = cComponent::registerSignal("gtuPosi
 } // namespace
 
 GtuMiddleware::GtuMiddleware() :
-    mVehicleDataProvider(Identity::randomStationId(getRNG(0)))
+    mVehicleDataProvider(0)
 {
 }
 
@@ -31,7 +31,8 @@ void GtuMiddleware::initialize(int stage)
         getFacilities().register_const(&mVehicleDataProvider);
 
         Identity identity;
-        identity.application = mVehicleDataProvider.station_id();
+        identity.application = Identity::randomStationId(getRNG(0));
+        mVehicleDataProvider.setStationId(identity.application);
         // TODO add GTU id to identity?
         emit(Identity::changeSignal, Identity::ChangeStationId, &identity);
     }


### PR DESCRIPTION
The local RNG map of a module is initialized in `cModuleType::create` with a call to `getEnvir()->preconfigure(module)`, so after the constructor of `VehicleMiddleware` has executed.  
Accessing a RNG via `getRNG(k)` in the constructor will sample the global RNG with index `k` instead of the RNG locally assigned via the the module's `rngMap`.
(I verified this with a debugger)

I chose `std::numeric_limits<uint32_t>::max()` as initial station id to poison the value before it has been properly initialized, but since that access would have to happen between execution of the constructor and the `InitStages::Self` stage of module initialization & OMNet++ is being used single-threaded, this should not be an issue.