### PR TITLE
Add ability to pass on arbitrary SUMO command line options

### DIFF
--- a/src/traci/PosixLauncher.cc
+++ b/src/traci/PosixLauncher.cc
@@ -67,6 +67,8 @@ void PosixLauncher::initialize()
     m_sumocfg = par("sumocfg").stringValue();
     m_port = par("port");
     m_seed = par("seed");
+
+    m_extra_options = par("extraOptions").stringValue();
 }
 
 void PosixLauncher::finish()
@@ -138,6 +140,11 @@ std::string PosixLauncher::command()
     command = std::regex_replace(command, port, std::to_string(m_port));
     command = std::regex_replace(command, seed, std::to_string(m_seed));
     command = std::regex_replace(command, run, run_number);
+
+    if (!m_extra_options.empty()) {
+      command.append(1, ' ').append(m_extra_options);
+    }
+
     return command;
 }
 

--- a/src/traci/PosixLauncher.h
+++ b/src/traci/PosixLauncher.h
@@ -31,6 +31,8 @@ private:
     int m_port;
     int m_seed;
     pid_t m_pid;
+
+    std::string m_extra_options;
 };
 
 } // namespace traci

--- a/src/traci/PosixLauncher.ned
+++ b/src/traci/PosixLauncher.ned
@@ -9,4 +9,7 @@ simple PosixLauncher like Launcher
         string sumocfg;
         int port = default(0);
         int seed = default(23423);
+
+        // additional SUMO command line options
+        string extraOptions = default("");
 }


### PR DESCRIPTION
These changes allow for `PosixLauncher` to pass on arbitrary command line options to SUMO, such as `--begin` or `--load-state`.

This enables different SUMO options for separate configurations or runs.