### PR TITLE
Fix member initialization in converting constructor for SensorVisualizationConfig

### DIFF
--- a/src/artery/envmod/sensor/SensorVisualizationConfig.cc
+++ b/src/artery/envmod/sensor/SensorVisualizationConfig.cc
@@ -13,9 +13,9 @@ SensorVisualizationConfig::SensorVisualizationConfig() :
 {
 }
 
-SensorVisualizationConfig::SensorVisualizationConfig(const cXMLElement* vis)
+SensorVisualizationConfig::SensorVisualizationConfig(const cXMLElement* vis) :
+    SensorVisualizationConfig()
 {
-    SensorVisualizationConfig config;
     if (vis) {
         auto attr_enabler = [vis](const char* name, bool& field) {
             cXMLElement* elem = vis->getFirstChildWithTag(name);


### PR DESCRIPTION
Running with UBSan enabled produces the following error (and similarly for all reads of members of `SensorVisualizationConfig`):
```
[...]/artery/src/artery/envmod/sensor/RadarSensor.cc:70:24: runtime error: load of value 12, which is not a valid value for type 'bool'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior [...]/artery/src/artery/envmod/sensor/RadarSensor.cc:70:24 in
```
Inspection of `SensorVisualizationConfig.cc` shows that the converting constructor is not delegating the default initialization of member variables to the default constructor. This results in uninitialized values when using sensor configurations without the visualization options set.

This is mostly not a problem as the `bool` members are still all set to false, at least in my debug builds with `-O0`. That is most likely not the case for release builds :slightly_smiling_face: .
