### PR TITLE
Moved StationType initializiation to VehicleDataProvider

### DIFF
--- a/src/artery/application/VehicleDataProvider.cc
+++ b/src/artery/application/VehicleDataProvider.cc
@@ -169,6 +169,39 @@ void VehicleDataProvider::update(const VehicleKinematics& dynamics)
 	calculateCurvatureConfidence();
 }
 
+void VehicleDataProvider::initializeStationType(const std::string& vclass)
+{
+    using vanetza::geonet::StationType;
+    StationType gnStationType;
+    if (vclass == "passenger" || vclass == "private" || vclass == "taxi") {
+        gnStationType = StationType::Passenger_Car;
+    } else if (vclass == "coach" || vclass == "delivery") {
+        gnStationType = StationType::Light_Truck;
+    } else if (vclass == "truck") {
+        gnStationType = StationType::Heavy_Truck;
+    } else if (vclass == "trailer") {
+        gnStationType = StationType::Trailer;
+    } else if (vclass == "bus") {
+        gnStationType = StationType::Bus;
+    } else if (vclass == "emergency" || vclass == "authority") {
+        gnStationType = StationType::Special_Vehicle;
+    } else if (vclass == "moped") {
+        gnStationType = StationType::Moped;
+    } else if (vclass == "motorcycle") {
+        gnStationType = StationType::Motorcycle;
+    } else if (vclass == "tram") {
+        gnStationType = StationType::Tram;
+    } else if (vclass == "bicycle") {
+        gnStationType = StationType::Cyclist;
+    } else if (vclass == "pedestrian") {
+        gnStationType = StationType::Pedestrian;
+    } else {
+        gnStationType = StationType::Unknown;
+    }
+
+    setStationType(gnStationType);
+}
+
 double VehicleDataProvider::mapOntoConfidence(AngularAcceleration x) const
 {
 	auto it = mConfidenceTable.lower_bound(x);

--- a/src/artery/application/VehicleDataProvider.h
+++ b/src/artery/application/VehicleDataProvider.h
@@ -50,6 +50,8 @@ class VehicleDataProvider
 		void update(const VehicleKinematics&);
 		omnetpp::SimTime updated() const { return mLastUpdate; }
 
+		void initializeStationType(const std::string& vclass);
+
 		const Position& position() const { return mVehicleKinematics.position; }
 		vanetza::units::GeoAngle longitude() const { return mVehicleKinematics.geo_position.longitude; } // positive for east
 		vanetza::units::GeoAngle latitude() const { return mVehicleKinematics.geo_position.latitude; } // positive for north

--- a/src/artery/application/VehicleMiddleware.cc
+++ b/src/artery/application/VehicleMiddleware.cc
@@ -27,8 +27,9 @@ void VehicleMiddleware::initialize(int stage)
     if (stage == InitStages::Self) {
         findHost()->subscribe(MobilityBase::stateChangedSignal, this);
         initializeVehicleController(par("mobilityModule"));
-        initializeStationType(mVehicleController->getVehicleClass());
         getFacilities().register_const(&mVehicleDataProvider);
+        mVehicleDataProvider.initializeStationType(mVehicleController->getVehicleClass());
+        setStationType(mVehicleDataProvider.getStationType());
         mVehicleDataProvider.update(getKinematics(*mVehicleController));
 
         Identity identity;
@@ -45,40 +46,6 @@ void VehicleMiddleware::finish()
 {
     Middleware::finish();
     findHost()->unsubscribe(MobilityBase::stateChangedSignal, this);
-}
-
-void VehicleMiddleware::initializeStationType(const std::string& vclass)
-{
-    using vanetza::geonet::StationType;
-    StationType gnStationType;
-    if (vclass == "passenger" || vclass == "private" || vclass == "taxi") {
-        gnStationType = StationType::Passenger_Car;
-    } else if (vclass == "coach" || vclass == "delivery") {
-        gnStationType = StationType::Light_Truck;
-    } else if (vclass == "truck") {
-        gnStationType = StationType::Heavy_Truck;
-    } else if (vclass == "trailer") {
-        gnStationType = StationType::Trailer;
-    } else if (vclass == "bus") {
-        gnStationType = StationType::Bus;
-    } else if (vclass == "emergency" || vclass == "authority") {
-        gnStationType = StationType::Special_Vehicle;
-    } else if (vclass == "moped") {
-        gnStationType = StationType::Moped;
-    } else if (vclass == "motorcycle") {
-        gnStationType = StationType::Motorcycle;
-    } else if (vclass == "tram") {
-        gnStationType = StationType::Tram;
-    } else if (vclass == "bicycle") {
-        gnStationType = StationType::Cyclist;
-    } else if (vclass == "pedestrian") {
-        gnStationType = StationType::Pedestrian;
-    } else {
-        gnStationType = StationType::Unknown;
-    }
-
-    setStationType(gnStationType);
-    mVehicleDataProvider.setStationType(gnStationType);
 }
 
 void VehicleMiddleware::initializeVehicleController(cPar& mobilityPar)

--- a/src/artery/application/VehicleMiddleware.h
+++ b/src/artery/application/VehicleMiddleware.h
@@ -22,7 +22,6 @@ class VehicleMiddleware : public Middleware
         void finish() override;
 
     protected:
-        void initializeStationType(const std::string&);
         void initializeVehicleController(omnetpp::cPar&);
         void receiveSignal(omnetpp::cComponent*, omnetpp::simsignal_t, omnetpp::cObject*, omnetpp::cObject*) override;
 

--- a/src/artery/envmod/EnvironmentModelObject.cc
+++ b/src/artery/envmod/EnvironmentModelObject.cc
@@ -82,6 +82,8 @@ EnvironmentModelObject::EnvironmentModelObject(const traci::VehicleController* v
     const auto halfLength = mLength * 0.5;
     mRadius = sqrt(halfWidth * halfWidth + halfLength * halfLength);
 
+    initializeStationType(mVehicleController->getVehicleClass());
+
     update();
 }
 


### PR DESCRIPTION
Hi Raphael,

we noticed that objects in the Envmod are of type `StationType::Unknown` and that the station type is only set in the VehicleMiddleware correctly. One suggestion to solve this would move `initializeStationType` to the `VehicleDataProvider`.

Kind regards
Alexander