### PR TITLE
gemv2: actually mark VehicleIndex R-tree as tainted after a vehicle's position has been updated

### DIFF
--- a/src/artery/inet/gemv2/VehicleIndex.cc
+++ b/src/artery/inet/gemv2/VehicleIndex.cc
@@ -91,7 +91,7 @@ void VehicleIndex::receiveSignal(cComponent* source, simsignal_t signal, const c
         return;
     }
 
-    bool mRtreeTainted = true;
+    mRtreeTainted = true;
 }
 
 bool VehicleIndex::anyBlockage(const Position& a, const Position& b) const


### PR DESCRIPTION
The declaration of `mRtreeTainted` shadows the member variable of `artery::gemv2::VehicleIndex` with the same name.

I don't think this has caused any problems yet.