### PR TITLE
Envmod: don't add origin point to polygon when creating a sensor cone with a field of view of 360 degrees

### DIFF
--- a/src/artery/envmod/sensor/SensorConfiguration.cc
+++ b/src/artery/envmod/sensor/SensorConfiguration.cc
@@ -22,7 +22,9 @@ std::vector<Position> createSensorArc(const SensorConfigRadar& config, const Pos
     const double sensorPositionDeg = relativeAngle(config.sensorPosition) / boost::units::degree::degrees;
 
     std::vector<Position> points;
-    points.push_back(Position {0.0, 0.0});
+    if (openingAngleDeg != 360) {
+        points.push_back(Position{0.0, 0.0});
+    }
 
     Position sensorBoundary(config.fieldOfView.range / boost::units::si::meters, 0.0);
     rotation rotateSensorBoundary(sensorPositionDeg - 0.5 * openingAngleDeg + egoHeadingDeg);


### PR DESCRIPTION
Sensors with a field of view of 360 degrees result in a cone polygon that has a spike and will fail validation when using `PreselectionRtree`.
The trivial fix is not adding the origin point.