### PR TITLE
Envmod: output failure type if a sensor cone fails validation

### DIFF
--- a/src/artery/envmod/PreselectionRtree.cc
+++ b/src/artery/envmod/PreselectionRtree.cc
@@ -26,8 +26,11 @@ void PreselectionRtree::update()
 std::vector<std::string> PreselectionRtree::select(const EnvironmentModelObject& ego, const SensorConfigRadar& config)
 {
     auto cone = createSensorArc(config, ego);
-    if (!boost::geometry::is_valid(cone)) {
-        throw omnetpp::cRuntimeError("polygon of sensor cone is invalid");
+    boost::geometry::validity_failure_type failure;
+    if (!boost::geometry::is_valid(cone, failure)) {
+        auto error_msg(std::string("polygon of sensor cone is invalid: ")
+                       .append(boost::geometry::validity_failure_type_message(failure)));
+        throw omnetpp::cRuntimeError(error_msg.c_str());
     }
 
     // Boost 1.58 accepted "cone" for intersection query. Fails for obscure reasons with 1.60+


### PR DESCRIPTION
When failing the validation of the sensor cone polygon, the failure type can be useful in determining a possible configuration error.