### PR TITLE
Enable opp_runall in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,8 @@ RUN apt-get update && apt-get install -y \
     libxerces-c3.2 \
     libxml2 \
     libzmq5 \
+    python3.9 \
+    make \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=omnetpp-build /omnetpp/bin /omnetpp/bin
 COPY --from=omnetpp-build /omnetpp/lib /omnetpp/lib
@@ -89,6 +91,8 @@ COPY --from=artery-build /artery/lib /artery/lib
 COPY --from=artery-build /artery/share/ned /artery/share/ned
 ENV SUMO_HOME /sumo/share/sumo
 ENV PATH /sumo/bin:/omnetpp/bin:$PATH
+RUN ln -s /usr/bin/python3.9 /usr/bin/python3 && \
+    ln -s /usr/bin/python3 /usr/bin/python
 RUN useradd -m artery
 RUN mkdir -p /scenario /results && chown -R artery:users /scenario /results
 USER artery

--- a/cmake/AddOppRun.cmake
+++ b/cmake/AddOppRun.cmake
@@ -214,6 +214,7 @@ function(generate_run_script)
     else()
         set(opp_run_executable ${OMNETPP_RUN})
     endif()
+    set(opp_runall_script ${OMNETPP_RUNALL})
 
     # substitute variables first, then generator expressions
     configure_file(${PROJECT_SOURCE_DIR}/cmake/run_artery.sh.in ${args_FILE} @ONLY)

--- a/cmake/FindOmnetPP.cmake
+++ b/cmake/FindOmnetPP.cmake
@@ -2,6 +2,7 @@ find_path(OMNETPP_ROOT NAMES bin/omnetpp PATHS ENV PATH PATH_SUFFIXES .. DOC "Pa
 find_path(OMNETPP_INCLUDE_DIR NAMES omnetpp.h PATHS ${OMNETPP_ROOT}/include DOC "OMNeT++ include directory")
 find_program(OMNETPP_MSGC NAMES nedtool opp_msgc PATHS ${OMNETPP_ROOT}/bin DOC "OMNeT++ message compiler")
 find_program(OMNETPP_RUN NAMES opp_run_release opp_run PATHS ${OMNETPP_ROOT}/bin DOC "OMNeT++ opp_run executable")
+find_program(OMNETPP_RUNALL NAMES opp_runall PATHS ${OMNETPP_ROOT}/bin DOC "OMNeT++ opp_runall script")
 find_program(OMNETPP_RUN_DEBUG NAMES opp_run_dbg opp_run PATHS ${OMNETPP_ROOT}/bin DOC "OMNeT++ opp_run_dbg executable")
 get_filename_component(OMNETPP_ROOT "${OMNETPP_ROOT}" REALPATH)
 mark_as_advanced(OMNETPP_INCLUDE_DIR OMNETPP_MSGC OMNETPP_ROOT OMNETPP_RUN OMNETPP_RUN_DEBUG)

--- a/cmake/run_artery.sh.in
+++ b/cmake/run_artery.sh.in
@@ -1,6 +1,21 @@
 #!/bin/bash
+OPP_RUNALL=@opp_runall_script@
 OPP_RUN=@opp_run_executable@
 NED_FOLDERS="@opp_run_ned_folders@"
 LIBRARIES="@opp_run_libraries@"
 
-$OPP_RUN -n $NED_FOLDERS $LIBRARIES $@
+RUNALL=false
+for arg do
+    shift
+    [[ "$arg" == -j* ]] && RUNALL=true && J=$arg && continue
+    [[ "$arg" == -b* ]] && RUNALL=true && B=$arg && continue
+    # run opp_runall with default values for -j* and -b* options by just specifying '--all'
+    [[ "$arg" == "--all" ]] && RUNALL=true && continue
+    set -- "$@" "$arg"
+done
+
+if [ "$RUNALL" = true ] ; then
+    $OPP_RUNALL $J $B $OPP_RUN -n $NED_FOLDERS $LIBRARIES $@
+else
+    $OPP_RUN -n $NED_FOLDERS $LIBRARIES $@
+fi


### PR DESCRIPTION
Currently, the Docker container can only run one run at a time because it starts OMNet++ with `opp_run`. This change allows to also use the python script `opp_runall` (see [11.20.2 Using opp_runall](https://doc.omnetpp.org/omnetpp/manual/#sec:run-sim:batches-using-opp-runall)) inside the container to run multiple runs of a config in parallel.

If arguments `-j` and/or `-b` are passed to the container, `opp_runall` is called instead of `opp_run` with them. Pass `--all` to use `opp_runall` without specifying any values for `-j` or `-b` (use their defaults, e.g. all available cores).

### Example

```bash
cd /path/to/artery/

# build image
docker build \
  --tag artery \
  .

# prepare scenario
cp -r extern/veins/examples/veins scenarios/artery/
# remove "../../extern/veins/examples/" from line 14 of omnetpp.ini

# start simulation
docker run -d \
  --name artery \
  --user $(id -u):$(id -g) \
  -v "$(pwd)/scenarios/artery":/scenario \
  -v "$(pwd)/results":/results \
  artery \
  -c envmod -j2  # this will run up to 2 runs of the envmod config in parallel
```