### PR TITLE
Support setOrder() for TraCI connection

### DIFF
--- a/src/traci/API.cc
+++ b/src/traci/API.cc
@@ -28,6 +28,7 @@ void API::connect(const ServerEndpoint& endpoint)
     while (true) {
         try {
             TraCIAPI::connect(endpoint.hostname, endpoint.port);
+            TraCIAPI::setOrder(endpoint.clientID);
             return;
         } catch (tcpip::SocketException&) {
             if (++tries < max_tries) {

--- a/src/traci/ConnectLauncher.cc
+++ b/src/traci/ConnectLauncher.cc
@@ -9,6 +9,7 @@ void ConnectLauncher::initialize()
 {
     m_endpoint.hostname = par("hostname").stringValue();
     m_endpoint.port = par("port");
+    m_endpoint.clientID = par("clientID");
 }
 
 ServerEndpoint ConnectLauncher::launch()

--- a/src/traci/ConnectLauncher.ned
+++ b/src/traci/ConnectLauncher.ned
@@ -6,4 +6,5 @@ simple ConnectLauncher like Launcher
         @class(traci::ConnectLauncher);
         string hostname = default("localhost");
         int port;
+		int clientID=default(1);
 }

--- a/src/traci/Launcher.h
+++ b/src/traci/Launcher.h
@@ -10,6 +10,7 @@ struct ServerEndpoint
 {
     std::string hostname;
     int port;
+    int clientID = 1;
     bool retry = false;
 };
 


### PR DESCRIPTION
This modifications allow to set the client id while connecting to Sumo, which in turn allows Artery to be one of multiple clients connected to the same sumo instance (e.g. to allow co-simulation of Artery and Caral using Sumo).