### PR TITLE
Release/cpservice core

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,7 +8,7 @@ AllowShortIfStatementsOnASingleLine: Never
 BreakBeforeBraces: Linux
 BreakInheritanceList: AfterColon
 BreakConstructorInitializers: AfterColon
-ColumnLimit: 140
+ColumnLimit: 160
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 IncludeBlocks: Regroup
@@ -28,4 +28,5 @@ IncludeCategories:
 IndentPPDirectives: BeforeHash
 IndentWidth: 4
 KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 2
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,25 @@
+---
+BasedOnStyle: Google
+AccessModifierOffset: -4
+AlignAfterOpenBracket: AlwaysBreak
+AlignEscapedNewlines: DontAlign
+BreakBeforeBraces: Linux
+BreakInheritanceList: AfterColon
+BreakConstructorInitializers: AfterColon
+ColumnLimit: 120
+ContinuationIndentWidth: 4
+IncludeCategories:
+  - Regex:           '^".*\.h.?.?"'
+    Priority:        1
+    SortPriority:    1
+  - Regex:           '^<.*\.h.?.?>'
+    Priority:        2
+    SortPriority:    2
+  - Regex:           '^<.*'
+    Priority:        3
+    SortPriority:    3
+  - Regex:           '.*'
+    Priority:        4
+    SortPriority:    4
+IndentWidth: 4
+...

--- a/.clang-format
+++ b/.clang-format
@@ -3,11 +3,15 @@ BasedOnStyle: Google
 AccessModifierOffset: -4
 AlignAfterOpenBracket: AlwaysBreak
 AlignEscapedNewlines: DontAlign
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: Never
 BreakBeforeBraces: Linux
 BreakInheritanceList: AfterColon
 BreakConstructorInitializers: AfterColon
-ColumnLimit: 120
+ColumnLimit: 140
+ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
+IncludeBlocks: Regroup
 IncludeCategories:
   - Regex:           '^".*\.h.?.?"'
     Priority:        1
@@ -21,5 +25,7 @@ IncludeCategories:
   - Regex:           '.*'
     Priority:        4
     SortPriority:    4
+IndentPPDirectives: BeforeHash
 IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: true
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -3,6 +3,7 @@ BasedOnStyle: Google
 AccessModifierOffset: -4
 AlignAfterOpenBracket: AlwaysBreak
 AlignEscapedNewlines: DontAlign
+AllowShortBlocksOnASingleLine: Empty
 AllowShortFunctionsOnASingleLine: InlineOnly
 AllowShortIfStatementsOnASingleLine: Never
 BreakBeforeBraces: Linux

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 ansible/*.retry
 scenarios/**/*.pyc
 scenarios/*/results/*
+scenarios/*/.cmdenv-log
+scenarios/*/.qtenvrc
 scenarios/*/.tkenvrc
 src/artery/messages/*_m.cc
 src/artery/messages/*_m.h

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ src/artery/messages/*_m.cc
 src/artery/messages/*_m.h
 www/
 .vagrant/
+
+# OMNeT++ IDE / Eclipse CDT auto-generated files
+.cproject
+.oppbuildspec
+.project
+.settings

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ www/
 .oppbuildspec
 .project
 .settings
+
+# CMake default directories
+build/

--- a/.nedfolders
+++ b/.nedfolders
@@ -1,0 +1,3 @@
+src/artery
+src/artery/envmod
+src/traci

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,37 @@ endif()
 set(BUILD_SHARED_LIBS ON CACHE INTERNAL "Cached for propagation to sub-projects with older CMake versions")
 
 check_git_submodule(PATH extern/vanetza REQUIRED_FILES CMakeLists.txt)
+
+# patch vanetza CPM definitions to support 32bit objectIDs
+execute_process(COMMAND patch --dry-run -p1 -s -i ${PROJECT_SOURCE_DIR}/vanetza_asn1_cpm_32bit-objectID.patch
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/extern/vanetza
+    OUTPUT_FILE /dev/null
+    RESULT_VARIABLE VANETZA_PATCH_TEST)
+if(VANETZA_PATCH_TEST EQUAL 0)
+    # actually patch vanetza
+    message(STATUS "patching vanetza CPM definitions")
+    execute_process(COMMAND patch -p1 -s -i ${PROJECT_SOURCE_DIR}/vanetza_asn1_cpm_32bit-objectID.patch
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/extern/vanetza
+        RESULT_VARIABLE VANETZA_PATCH_SUCCESS)
+    if(VANETZA_PATCH_SUCCESS EQUAL 0)
+        message(STATUS "vanetza CPM definitions successfully patched")
+    elseif()
+        message(STATUS "patching vanetza CPM definitions failed -- manual intervention necessary")
+    endif()
+else()
+    execute_process(COMMAND patch --dry-run -R -p1 -s -i ${PROJECT_SOURCE_DIR}/vanetza_asn1_cpm_32bit-objectID.patch
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/extern/vanetza
+        OUTPUT_FILE /dev/null
+        RESULT_VARIABLE VANETZA_PATCH_TEST_REVERSE)
+    if(VANETZA_PATCH_TEST_REVERSE EQUAL 0)
+        # patch already applied
+        message(STATUS "vanetza CPM definitions patch already applied")
+    else()
+        message(STATUS "testing patch integrity by applying vanetza CPM defintions patch in reverse failed -- manual intervention necessary")
+    endif()
+endif()
+
+
 set(VANETZA_INSTALL ON)
 add_subdirectory(${PROJECT_SOURCE_DIR}/extern/vanetza)
 mark_as_advanced(BUILD_BENCHMARK BUILD_CERTIFY BUILD_SOCKTAP BUILD_TESTS BUILD_USING_CONAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,33 +35,39 @@ set(BUILD_SHARED_LIBS ON CACHE INTERNAL "Cached for propagation to sub-projects 
 
 check_git_submodule(PATH extern/vanetza REQUIRED_FILES CMakeLists.txt)
 
-# patch vanetza CPM definitions to support 32bit objectIDs
-execute_process(COMMAND patch --dry-run -p1 -s -i ${PROJECT_SOURCE_DIR}/vanetza_asn1_cpm_32bit-objectID.patch
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/extern/vanetza
-    OUTPUT_FILE /dev/null
-    RESULT_VARIABLE VANETZA_PATCH_TEST)
-if(VANETZA_PATCH_TEST EQUAL 0)
-    # actually patch vanetza
-    message(STATUS "patching vanetza CPM definitions")
-    execute_process(COMMAND patch -p1 -s -i ${PROJECT_SOURCE_DIR}/vanetza_asn1_cpm_32bit-objectID.patch
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/extern/vanetza
-        RESULT_VARIABLE VANETZA_PATCH_SUCCESS)
-    if(VANETZA_PATCH_SUCCESS EQUAL 0)
-        message(STATUS "vanetza CPM definitions successfully patched")
-    elseif()
-        message(STATUS "patching vanetza CPM definitions failed -- manual intervention necessary")
-    endif()
-else()
-    execute_process(COMMAND patch --dry-run -R -p1 -s -i ${PROJECT_SOURCE_DIR}/vanetza_asn1_cpm_32bit-objectID.patch
+option(PATCH_VANETZA_CPM "Patch vanetza CPM definitions" ON)
+
+if (PATCH_VANETZA_CPM)
+    # patch vanetza CPM definitions to support 32bit objectIDs
+    execute_process(COMMAND patch --dry-run -p1 -s -i ${PROJECT_SOURCE_DIR}/vanetza_asn1_cpm_32bit-objectID.patch
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/extern/vanetza
         OUTPUT_FILE /dev/null
-        RESULT_VARIABLE VANETZA_PATCH_TEST_REVERSE)
-    if(VANETZA_PATCH_TEST_REVERSE EQUAL 0)
-        # patch already applied
-        message(STATUS "vanetza CPM definitions patch already applied")
+        RESULT_VARIABLE VANETZA_PATCH_TEST)
+    if(VANETZA_PATCH_TEST EQUAL 0)
+        # actually patch vanetza
+        message(STATUS "patching vanetza CPM definitions")
+        execute_process(COMMAND patch -p1 -s -i ${PROJECT_SOURCE_DIR}/vanetza_asn1_cpm_32bit-objectID.patch
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/extern/vanetza
+            RESULT_VARIABLE VANETZA_PATCH_SUCCESS)
+        if(VANETZA_PATCH_SUCCESS EQUAL 0)
+            message(STATUS "vanetza CPM definitions successfully patched")
+        elseif()
+            message(STATUS "patching vanetza CPM definitions failed -- manual intervention necessary")
+        endif()
     else()
-        message(STATUS "testing patch integrity by applying vanetza CPM defintions patch in reverse failed -- manual intervention necessary")
+        execute_process(COMMAND patch --dry-run -R -p1 -s -i ${PROJECT_SOURCE_DIR}/vanetza_asn1_cpm_32bit-objectID.patch
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/extern/vanetza
+            OUTPUT_FILE /dev/null
+            RESULT_VARIABLE VANETZA_PATCH_TEST_REVERSE)
+        if(VANETZA_PATCH_TEST_REVERSE EQUAL 0)
+            # patch already applied
+            message(STATUS "vanetza CPM definitions patch already applied")
+        else()
+            message(STATUS "testing patch integrity by applying vanetza CPM defintions patch in reverse failed -- manual intervention necessary")
+        endif()
     endif()
+elseif()
+    message(STATUS "vanetza CPM patching disabled")
 endif()
 
 

--- a/src/artery/application/ItsG5BaseService.cc
+++ b/src/artery/application/ItsG5BaseService.cc
@@ -84,7 +84,12 @@ int ItsG5BaseService::numInitStages() const
 void ItsG5BaseService::initialize(int stage)
 {
 	if (stage == InitStages::Prepare) {
-		Middleware* middleware = dynamic_cast<Middleware*>(getParentModule());
+		// If this service is part of a Compound Module the Middleware is its grand parent
+		auto* parent = getParentModule();
+		if (!parent->getModuleType()->isSimple()) {
+			parent = parent->getParentModule();
+		}
+		Middleware* middleware = dynamic_cast<Middleware*>(parent);
 		if (middleware == nullptr) {
 			throw cRuntimeError("Middleware not found");
 		}

--- a/src/artery/application/ItsG5BaseService.cc
+++ b/src/artery/application/ItsG5BaseService.cc
@@ -18,6 +18,7 @@
 
 #include "artery/application/ItsG5Service.h"
 #include "artery/application/Middleware.h"
+#include "artery/utility/InitStages.h"
 #include <inet/common/ModuleAccess.h>
 #include <omnetpp/clog.h>
 #include <cassert>
@@ -75,14 +76,30 @@ cModule* ItsG5BaseService::findHost()
 	return inet::findContainingNode(m_middleware);
 }
 
-void ItsG5BaseService::initialize()
+int ItsG5BaseService::numInitStages() const
 {
-	Middleware* middleware = dynamic_cast<Middleware*>(getParentModule());
-	if (middleware == nullptr) {
-		throw cRuntimeError("Middleware not found");
+	return (InitStages::Prepare + 1);
+}
+
+void ItsG5BaseService::initialize(int stage)
+{
+	if (stage == InitStages::Prepare) {
+		Middleware* middleware = dynamic_cast<Middleware*>(getParentModule());
+		if (middleware == nullptr) {
+			throw cRuntimeError("Middleware not found");
+		}
+
+		m_middleware = middleware;
 	}
 
-	m_middleware = middleware;
+	// To prevent that derived classes need to be aware of the multi-stage initialization of this base class
+	// call the plain initialize() method at stage 0. This way for these derived classes it is sufficient
+	// to just override this method if they don't perform multi-stage initialization themself, however if
+	// they also perform multi-stage initialization they need to take into account the required stages
+	// of this base class.
+	if (stage == 0) {
+		initialize();
+	}
 }
 
 void ItsG5BaseService::finish()

--- a/src/artery/application/ItsG5BaseService.h
+++ b/src/artery/application/ItsG5BaseService.h
@@ -76,7 +76,9 @@ class ItsG5BaseService :
 		const std::set<TransportDescriptor>& getTransportDescriptors() const { return m_listeners; }
 
 	protected:
-		void initialize() override;
+		int numInitStages() const override;
+		using omnetpp::cSimpleModule::initialize;
+		void initialize(int stage) override;
 		void finish() override;
 		void request(const vanetza::btp::DataRequestB&, std::unique_ptr<vanetza::DownPacket>, const NetworkInterface* = nullptr);
 		void indicate(const vanetza::btp::DataIndication&, std::unique_ptr<vanetza::UpPacket>, const NetworkInterface&) override;

--- a/src/artery/application/LocalDynamicMap.cc
+++ b/src/artery/application/LocalDynamicMap.cc
@@ -40,7 +40,7 @@ void LocalDynamicMap::dropExpired()
 {
     const auto now = omnetpp::simTime();
     for (auto it = mCaMessages.begin(); it != mCaMessages.end();) {
-        if (it->second.expiry < now) {
+        if (it->second.expiry() < now) {
             it = mCaMessages.erase(it);
         } else {
             ++it;
@@ -51,24 +51,13 @@ void LocalDynamicMap::dropExpired()
 unsigned LocalDynamicMap::count(const CamPredicate& predicate) const
 {
     return std::count_if(mCaMessages.begin(), mCaMessages.end(),
-            [&predicate](const std::pair<const StationID, AwarenessEntry>& map_entry) {
-                const Cam& cam = map_entry.second.object.asn1();
-                return predicate(cam);
+            [&predicate](const AwarenessEntries::value_type& map_entry) {
+                return predicate(map_entry.second.cam());
             });
 }
 
-std::shared_ptr<const LocalDynamicMap::Cam> LocalDynamicMap::getCam(StationID stationId) const
-{
-    auto cam = mCaMessages.find(stationId);
-    if (cam != mCaMessages.end()) {
-        return cam->second.object.shared_ptr();
-    }
-
-    return nullptr;
-}
-
 LocalDynamicMap::AwarenessEntry::AwarenessEntry(const CaObject& obj, omnetpp::SimTime t) :
-    expiry(t), object(obj)
+    mExpiry(t), mObject(obj)
 {
 }
 

--- a/src/artery/application/LocalDynamicMap.cc
+++ b/src/artery/application/LocalDynamicMap.cc
@@ -57,6 +57,16 @@ unsigned LocalDynamicMap::count(const CamPredicate& predicate) const
             });
 }
 
+std::shared_ptr<const LocalDynamicMap::Cam> LocalDynamicMap::getCam(StationID stationId) const
+{
+    auto cam = mCaMessages.find(stationId);
+    if (cam != mCaMessages.end()) {
+        return cam->second.object.shared_ptr();
+    }
+
+    return nullptr;
+}
+
 LocalDynamicMap::AwarenessEntry::AwarenessEntry(const CaObject& obj, omnetpp::SimTime t) :
     expiry(t), object(obj)
 {

--- a/src/artery/application/LocalDynamicMap.h
+++ b/src/artery/application/LocalDynamicMap.h
@@ -6,6 +6,7 @@
 #include <vanetza/asn1/cam.hpp>
 #include <functional>
 #include <map>
+#include <memory>
 
 namespace artery
 {
@@ -23,6 +24,7 @@ public:
     void updateAwareness(const CaObject&);
     void dropExpired();
     unsigned count(const CamPredicate&) const;
+    std::shared_ptr<const Cam> getCam(StationID stationId) const;
 
 private:
     struct AwarenessEntry

--- a/src/artery/application/LocalDynamicMap.h
+++ b/src/artery/application/LocalDynamicMap.h
@@ -4,7 +4,6 @@
 #include "artery/application/CaObject.h"
 #include <omnetpp/simtime.h>
 #include <vanetza/asn1/cam.hpp>
-#include <cstdint>
 #include <functional>
 #include <map>
 
@@ -16,7 +15,7 @@ class Timer;
 class LocalDynamicMap
 {
 public:
-    using StationID = uint32_t;
+    using StationID = StationID_t;
     using Cam = vanetza::asn1::Cam;
     using CamPredicate = std::function<bool(const Cam&)>;
 

--- a/src/artery/application/LocalDynamicMap.h
+++ b/src/artery/application/LocalDynamicMap.h
@@ -16,29 +16,36 @@ class Timer;
 class LocalDynamicMap
 {
 public:
-    using StationID = StationID_t;
     using Cam = vanetza::asn1::Cam;
     using CamPredicate = std::function<bool(const Cam&)>;
+
+    class AwarenessEntry
+    {
+    public:
+        AwarenessEntry(const CaObject&, omnetpp::SimTime);
+        AwarenessEntry(AwarenessEntry&&) = default;
+        AwarenessEntry& operator=(AwarenessEntry&&) = default;
+
+        omnetpp::SimTime expiry() const { return mExpiry; }
+        const Cam& cam() const { return mObject.asn1(); }
+        std::shared_ptr<const Cam> camPtr() const { return mObject.shared_ptr(); }
+
+    private:
+        omnetpp::SimTime mExpiry;
+        CaObject mObject;
+    };
+
+    using AwarenessEntries = std::map<StationID_t, AwarenessEntry>;
 
     LocalDynamicMap(const Timer&);
     void updateAwareness(const CaObject&);
     void dropExpired();
     unsigned count(const CamPredicate&) const;
-    std::shared_ptr<const Cam> getCam(StationID stationId) const;
+    const AwarenessEntries& allEntries() const { return mCaMessages; }
 
 private:
-    struct AwarenessEntry
-    {
-        AwarenessEntry(const CaObject&, omnetpp::SimTime);
-        AwarenessEntry(AwarenessEntry&&) = default;
-        AwarenessEntry& operator=(AwarenessEntry&&) = default;
-
-        omnetpp::SimTime expiry;
-        CaObject object;
-    };
-
     const Timer& mTimer;
-    std::map<StationID, AwarenessEntry> mCaMessages;
+    AwarenessEntries mCaMessages;
 };
 
 } // namespace artery

--- a/src/artery/application/Middleware.cc
+++ b/src/artery/application/Middleware.cc
@@ -110,7 +110,20 @@ void Middleware::initializeServices(int stage)
             module->scheduleStart(simTime());
             // defer final module initialisation until service is attached to middleware
 
-            ItsG5BaseService* service = dynamic_cast<ItsG5BaseService*>(module);
+            // Like the Simple Module case uses the C++ class to determine if the module does
+            // implement a service search for the first matching Submodule that implements a service
+            // in the Compound Module case
+            ItsG5BaseService* service = nullptr;
+            if (!module_type->isSimple()) {
+                for (cModule::SubmoduleIterator it(module); !it.end(); ++it) {
+                    service = dynamic_cast<ItsG5BaseService*>(*it);
+                    if (service) {
+                        break;
+                    }
+                }
+            } else {
+                service = dynamic_cast<ItsG5BaseService*>(module);
+            }
             if (service) {
                 unsigned ports = 0;
                 unsigned channels = 0;

--- a/src/artery/application/VehicleMiddleware.cc
+++ b/src/artery/application/VehicleMiddleware.cc
@@ -29,12 +29,19 @@ void VehicleMiddleware::initialize(int stage)
         findHost()->subscribe(MobilityBase::stateChangedSignal, this);
         initializeVehicleController(par("mobilityModule"));
         initializeStationType(mVehicleController->getVehicleClass());
+
+        auto path = findHost()->getFullPath();
+        auto i0 = path.find("[");
+        auto i1 = path.find("]");
+        auto stationId = std::stoul(path.substr(i0+1, i1-i0-1));
+        mVehicleDataProvider.setStationId(stationId);
+
         getFacilities().register_const(&mVehicleDataProvider);
         mVehicleDataProvider.update(getKinematics(*mVehicleController));
 
         Identity identity;
         identity.traci = mVehicleController->getVehicleId();
-        identity.application = Identity::randomStationId(getRNG(0));
+        identity.application = mVehicleDataProvider.getStationId();
         mVehicleDataProvider.setStationId(identity.application);
         emit(Identity::changeSignal, Identity::ChangeTraCI | Identity::ChangeStationId, &identity);
     }

--- a/src/artery/envmod/CMakeLists.txt
+++ b/src/artery/envmod/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_artery_feature(envmod
+    CarIdentityRegistrant.cc
     EnvironmentModelObject.cc
     GlobalEnvironmentModel.cc
     LocalEnvironmentModel.cc

--- a/src/artery/envmod/CarIdentityRegistrant.cc
+++ b/src/artery/envmod/CarIdentityRegistrant.cc
@@ -1,0 +1,48 @@
+#include "artery/envmod/CarIdentityRegistrant.h"
+#include "artery/utility/IdentityRegistry.h"
+#include "artery/traci/MobilityBase.h"
+#include "inet/common/ModuleAccess.h"
+
+
+namespace artery
+{
+
+Define_Module(CarIdentityRegistrant)
+
+void CarIdentityRegistrant::initialize()
+{
+	initializeIdentity();
+	registerIdentity();
+}
+
+void CarIdentityRegistrant::initializeIdentity()
+{
+	auto parent = this->getParentModule();
+	auto mobility = dynamic_cast<MobilityBase*>(parent->getSubmodule("mobility", -1));
+	if (!mobility) {
+		throw omnetpp::cRuntimeError("no suitable mobility module found");
+	}
+	auto controller = mobility->getVehicleController();
+
+	auto traciId = controller->getVehicleId();
+
+	auto path = parent->getFullPath();
+	auto i0 = path.find("[");
+	auto i1 = path.find("]");
+	auto stationId = std::stoul(path.substr(i0+1, i1-i0-1));
+
+	mIdentity.application = stationId;
+	mIdentity.traci = traciId;
+}
+
+void CarIdentityRegistrant::registerIdentity()
+{
+	emit(artery::IdentityRegistry::updateSignal, &mIdentity);
+}
+
+void CarIdentityRegistrant::finish()
+{
+	emit(artery::IdentityRegistry::removeSignal, &mIdentity);
+}
+
+} // namespace artery

--- a/src/artery/envmod/CarIdentityRegistrant.cc
+++ b/src/artery/envmod/CarIdentityRegistrant.cc
@@ -31,6 +31,7 @@ void CarIdentityRegistrant::initializeIdentity()
 	auto i1 = path.find("]");
 	auto stationId = std::stoul(path.substr(i0+1, i1-i0-1));
 
+	mIdentity.host = parent;
 	mIdentity.application = stationId;
 	mIdentity.traci = traciId;
 }

--- a/src/artery/envmod/CarIdentityRegistrant.cc
+++ b/src/artery/envmod/CarIdentityRegistrant.cc
@@ -1,6 +1,6 @@
 #include "artery/envmod/CarIdentityRegistrant.h"
 #include "artery/utility/IdentityRegistry.h"
-#include "artery/traci/MobilityBase.h"
+#include "artery/traci/VehicleMobility.h"
 #include "inet/common/ModuleAccess.h"
 
 
@@ -18,7 +18,7 @@ void CarIdentityRegistrant::initialize()
 void CarIdentityRegistrant::initializeIdentity()
 {
 	auto parent = this->getParentModule();
-	auto mobility = dynamic_cast<MobilityBase*>(parent->getSubmodule("mobility", -1));
+	auto mobility = dynamic_cast<VehicleMobility*>(parent->getSubmodule("mobility", -1));
 	if (!mobility) {
 		throw omnetpp::cRuntimeError("no suitable mobility module found");
 	}

--- a/src/artery/envmod/CarIdentityRegistrant.h
+++ b/src/artery/envmod/CarIdentityRegistrant.h
@@ -1,0 +1,21 @@
+#include "artery/utility/Identity.h"
+#include <omnetpp/csimplemodule.h>
+
+
+namespace artery
+{
+
+class CarIdentityRegistrant : public omnetpp::cSimpleModule
+{
+	protected:
+		void initialize() override;
+		void finish() override;
+
+	private:
+		artery::Identity mIdentity;
+
+		void initializeIdentity();
+		void registerIdentity();
+};
+
+} // namespace artery

--- a/src/artery/envmod/CarIdentityRegistrant.ned
+++ b/src/artery/envmod/CarIdentityRegistrant.ned
@@ -1,0 +1,9 @@
+package artery.envmod;
+
+simple CarIdentityRegistrant
+{
+    parameters:
+        @class(CarIdentityRegistrant);
+        @signal[Identity.update](type=artery::Identity);
+        @signal[Identity.remove](type=artery::Identity);
+}

--- a/src/artery/envmod/CarIdentityRegistrant.ned
+++ b/src/artery/envmod/CarIdentityRegistrant.ned
@@ -4,6 +4,6 @@ simple CarIdentityRegistrant
 {
     parameters:
         @class(CarIdentityRegistrant);
-        @signal[Identity.update](type=artery::Identity);
-        @signal[Identity.remove](type=artery::Identity);
+        @signal[IdentityUpdated](type=artery::Identity);
+        @signal[IdentityRemoved](type=artery::Identity);
 }

--- a/src/artery/envmod/PlainVehicle.ned
+++ b/src/artery/envmod/PlainVehicle.ned
@@ -1,0 +1,18 @@
+package artery.envmod;
+
+import artery.inet.PlainVehicle;
+import artery.envmod.CarIdentityRegistrant;
+
+module PlainVehicle extends artery.inet.PlainVehicle
+{
+    parameters:
+        @display("i=blocki/process;is=vs");
+        @labels(node);
+
+    submodules:
+        carIdentityRegistrant: CarIdentityRegistrant {
+            parameters:
+                @display("p=53,300");
+        }
+
+}

--- a/src/artery/envmod/service/EnvmodPrinter.cc
+++ b/src/artery/envmod/service/EnvmodPrinter.cc
@@ -51,6 +51,7 @@ void EnvmodPrinter::printSensorObjectList(const std::string& title, const Tracke
         const auto& vd = obj_ptr.lock()->getVehicleData();
         EV_DETAIL
             << "station ID: " << vd.station_id()
+            << " TraCI ID: " << obj_ptr.lock()->getExternalId()
             << " lon: " << vd.longitude()
             << " lat: " << vd.latitude()
             << " speed: " << vd.speed()

--- a/src/artery/envmod/service/EnvmodPrinter.cc
+++ b/src/artery/envmod/service/EnvmodPrinter.cc
@@ -46,12 +46,14 @@ void EnvmodPrinter::printSensorObjectList(const std::string& title, const Tracke
 
     for (const auto& obj : objs)
     {
-        std::weak_ptr<EnvironmentModelObject> obj_ptr = obj.first;
-        if (obj_ptr.expired()) continue; /*< objects remain in tracking briefly after leaving simulation */
-        const auto& vd = obj_ptr.lock()->getVehicleData();
+        const auto obj_ptr = obj.first.lock();
+        if (!obj_ptr) {
+            continue; /*< objects remain in tracking briefly after leaving simulation */
+        }
+        const auto& vd = obj_ptr->getVehicleData();
         EV_DETAIL
             << "station ID: " << vd.station_id()
-            << " TraCI ID: " << obj_ptr.lock()->getExternalId()
+            << " TraCI ID: " << obj_ptr->getExternalId()
             << " lon: " << vd.longitude()
             << " lat: " << vd.latitude()
             << " speed: " << vd.speed()

--- a/vanetza_asn1_cpm_32bit-objectID.patch
+++ b/vanetza_asn1_cpm_32bit-objectID.patch
@@ -1,0 +1,35 @@
+diff --git a/vanetza/asn1/its/PerceivedObject.c b/vanetza/asn1/its/PerceivedObject.c
+index e6fe8b4b..6b8c5ca6 100644
+--- a/vanetza/asn1/its/PerceivedObject.c
++++ b/vanetza/asn1/its/PerceivedObject.c
+@@ -55,7 +55,7 @@ asn_TYPE_member_t asn_MBR_PerceivedObject_1[] = {
+ 	{ ATF_NOFLAGS, 0, offsetof(struct PerceivedObject, objectID),
+ 		(ASN_TAG_CLASS_CONTEXT | (0 << 2)),
+ 		-1,	/* IMPLICIT tag at current level */
+-		&asn_DEF_Identifier,
++		&asn_DEF_StationID,
+ 		0,
+ 		{ 0, 0, 0 },
+ 		0, 0, /* No default value */
+diff --git a/vanetza/asn1/its/PerceivedObject.h b/vanetza/asn1/its/PerceivedObject.h
+index 25d7ec10..37800ea6 100644
+--- a/vanetza/asn1/its/PerceivedObject.h
++++ b/vanetza/asn1/its/PerceivedObject.h
+@@ -12,7 +12,7 @@
+ #include "asn_application.h"
+ 
+ /* Including external dependencies */
+-#include "Identifier.h"
++#include "StationID.h"
+ #include "TimeOfMeasurement.h"
+ #include "ObjectAge.h"
+ #include "ObjectConfidence.h"
+@@ -40,7 +40,7 @@ struct MatchedPosition;
+ 
+ /* PerceivedObject */
+ typedef struct PerceivedObject {
+-	Identifier_t	 objectID;
++	StationID_t	 objectID;
+ 	struct SensorIdList	*sensorIDList;	/* OPTIONAL */
+ 	TimeOfMeasurement_t	 timeOfMeasurement;
+ 	ObjectAge_t	*objectAge;	/* OPTIONAL */


### PR DESCRIPTION
These are the core Artery changes required for #249.

The way the patching of the CP message format is done is not optimal, it results in a dirty source tree. This wasn't done by me because back in the days i had no idea about that CMake stuff, this is a bit different now. It would be better to copy the source files that require patching into the binary tree and patch them there, but currently this doesn't work because the files use quoted includes.

If i understand the CMake files of Vanetza right, they contain the code to actually compile the C++ files that are included in the repository from the ASN1 files and perform some intense post-processing. This post-processing also changes the angle includes into quoted includes. If the angle includes would be kept, putting the binary tree before the source tree in the include path would be sufficient to pick up the patched header file instead of using the original one (selecting the correct source file is easily done by CMake code).