### PR TITLE
Fix exception message in Identity.cc

### DIFF
--- a/src/artery/utility/Identity.cc
+++ b/src/artery/utility/Identity.cc
@@ -54,7 +54,7 @@ uint32_t Identity::deriveStationId(omnetpp::cModule* mod, const std::string& bas
     } else if (basis == "module-index") {
         return mod->isVector() ? mod->getIndex() : -1;
     } else {
-        throw omnetpp::cRuntimeError("unknown basis %s to derive station id from", basis);
+        throw omnetpp::cRuntimeError("unknown basis %s to derive station id from", basis.c_str());
         return 0;
     }
 }


### PR DESCRIPTION
When compiling with Clang-14 I get the following error:

```
home/artery/artery/src/artery/utility/Identity.cc:57:84: error: cannot pass non-trivial object of type 'const std::string' (aka 'const basic_string<char>') to variadic constructor; expected type from format string was 'char *' [-Wnon-pod-varargs]
        throw omnetpp::cRuntimeError("unknown basis %s to derive station id from", basis);
                                                    ~~                             ^~~~~
/home/artery/artery/src/artery/utility/Identity.cc:57:84: note: did you mean to call the c_str() method?
        throw omnetpp::cRuntimeError("unknown basis %s to derive station id from", basis);
                                                                                   ^
                                                                                        .c_str()
```

Apparently, handling non-POD objects in a variadic constructor is implementation-specific and while GCC supports it, Clang raises an error.
