### PR TITLE
Update visualization when having circular sensor

### DIFF
--- a/src/artery/envmod/sensor/FovSensor.cc
+++ b/src/artery/envmod/sensor/FovSensor.cc
@@ -256,7 +256,8 @@ void FovSensor::refreshDisplay() const
             delete mLinesOfSightFigure->removeFigure(0);
         }
 
-        const Position& startPoint = mLastDetection->sensorCone.front();
+        //const Position& startPoint = mLastDetection->sensorCone.front();
+        const Position& startPoint = mLastDetection->sensorOrigin;
 
         for (const Position& endPoint : mLastDetection->visiblePoints) {
             auto line = new cLineFigure();


### PR DESCRIPTION
When having a circular sensor, the visualization of the lineOfSight is wrong.