### PR TITLE
Added parallel flag to cmake build step

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -96,8 +96,8 @@ Are you still with us? Congratulations, you are almost done!
 Invoke following commands from **$ARTERY_PATH** to create a *build* directory for Artery, configure the build directory with CMake and finally build Artery there.
 
 ```shell
-mkdir build    # Create directory "build"
-cmake -B build    # Generate the project's buildsystem in directory "build"
+mkdir build                 # Create directory "build"
+cmake -B build              # Generate the project's buildsystem in directory "build"
 cmake --build build -j X    # Build the project in directory "build"
 ```
 where `-j X` is a optional flag and `X` is the amount of threads the build-process should use.

--- a/docs/install.md
+++ b/docs/install.md
@@ -102,7 +102,7 @@ cmake ..
 cmake --build . --parallel X
 ```
 where `--parallel X` is a optional flag and `X` is the amount of threads the build-process should use.
-Ommiting the flag leads to a singlethreaded build process. 
+Ommiting the flag leads to a singlethreaded build-process. 
 
 !!! note
     It is not a strict requirement that Artery's build directory is located at *$ARTERY_PATH/build*.

--- a/docs/install.md
+++ b/docs/install.md
@@ -97,11 +97,9 @@ Invoke following commands from **$ARTERY_PATH** to create a *build* directory fo
 
 ```shell
 mkdir build
-cd build
-cmake ..
-cmake --build . --parallel X
+cmake --build build -j X
 ```
-where `--parallel X` is a optional flag and `X` is the amount of threads the build-process should use.
+where `-j X` is a optional flag and `X` is the amount of threads the build-process should use.
 Ommiting the flag leads to a singlethreaded build-process. 
 
 !!! note

--- a/docs/install.md
+++ b/docs/install.md
@@ -99,8 +99,10 @@ Invoke following commands from **$ARTERY_PATH** to create a *build* directory fo
 mkdir build
 cd build
 cmake ..
-cmake --build .
+cmake --build . --parallel X
 ```
+where `--parallel X` is a optional flag and `X` is the amount of threads the build-process should use.
+Ommiting the flag leads to a singlethreaded build process. 
 
 !!! note
     It is not a strict requirement that Artery's build directory is located at *$ARTERY_PATH/build*.

--- a/docs/install.md
+++ b/docs/install.md
@@ -96,8 +96,9 @@ Are you still with us? Congratulations, you are almost done!
 Invoke following commands from **$ARTERY_PATH** to create a *build* directory for Artery, configure the build directory with CMake and finally build Artery there.
 
 ```shell
-mkdir build
-cmake --build build -j X
+mkdir build    # Create directory "build"
+cmake -B build    # Generate the project's buildsystem in directory "build"
+cmake --build build -j X    # Build the project in directory "build"
 ```
 where `-j X` is a optional flag and `X` is the amount of threads the build-process should use.
 Ommiting the flag leads to a singlethreaded build-process. 


### PR DESCRIPTION
I think this is quite useful as I did not know of this flag. So I ran the build-process in a single thread the first time I built it, which takes a lot of time.