### PR TITLE
Add IMPORTED_NO_SONAME in Omnet++ setup 

### DIFF
--- a/cmake/FindOmnetPP.cmake
+++ b/cmake/FindOmnetPP.cmake
@@ -42,6 +42,7 @@ foreach(_library IN LISTS _libraries)
         IMPORTED_LOCATION_DEBUG ${OMNETPP_${_LIBRARY}_LIBRARY_DEBUG}
         INTERFACE_LINK_LIBRARIES OmnetPP::header)
     set_property(TARGET OmnetPP::${_library} PROPERTY IMPORTED_CONFIGURATIONS "DEBUG" "RELEASE")
+    set_property(TARGET OmnetPP::${_library} PROPERTY IMPORTED_NO_SONAME ON)
     mark_as_advanced(OMNETPP_${_LIBRARY}_LIBRARY_RELEASE OMNETPP_${_LIBRARY}_LIBRARY_DEBUG)
 endforeach()
 unset(_libraries)


### PR DESCRIPTION
Hey,

According to cmake documentation on imported targets, setting this property may help compiler (linker specifically) to avoid using relative paths when generating linking command.
Ref: https://cmake.org/cmake/help/latest/command/add_library.html#imported-libraries

> If the referenced library file has a SONAME (or on macOS, has a LC_ID_DYLIB starting in @rpath/), the value of that field should be set in the IMPORTED_SONAME target property. If the referenced library file does not have a SONAME, but the platform supports it, then the IMPORTED_NO_SONAME target property should be set.

I had a problem with linker when cmake used relative path for shared library _OmnetPP::envir_, linked here
https://github.com/riebl/artery/blob/master/cmake/AddOppTarget.cmake#L69

It used to adjust path to .so lib just as it does with static targets, like _../.../path/to/omnetpp/libs/liboppenvir.so_.
With IMPORTED_NO_SONAME set compiler command on my platform looks like this:
`
/usr/bin/c++ -fPIC -m64 -g -m64 -shared ... ../../extern/libINET.so -loppenvir_dbg ...
`
With path to Omnet++ libs included in rpath of compiled .so.