### PR TITLE
Better python handling in CMake

### DIFF
--- a/src/artery/storyboard/CMakeLists.txt
+++ b/src/artery/storyboard/CMakeLists.txt
@@ -26,11 +26,20 @@ add_artery_feature(storyboard
     Vehicle.cc
 )
 
-find_package(PythonLibs REQUIRED)
 add_library(pybind11 INTERFACE)
-target_include_directories(pybind11 INTERFACE
-    ${PROJECT_SOURCE_DIR}/extern/pybind11/include
-    ${PYTHON_INCLUDE_DIRS})
-target_link_libraries(pybind11 INTERFACE ${PYTHON_LIBRARIES})
+if(NOT (CMAKE_VERSION VERSION_LESS 3.12))
+    find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+    target_include_directories(pybind11 INTERFACE
+        ${PROJECT_SOURCE_DIR}/extern/pybind11/include
+        ${Python3_INCLUDE_DIRS})
+    target_link_libraries(pybind11 INTERFACE ${Python3_LIBRARIES})
+else()
+    find_package(PythonLibs REQUIRED)
+    target_include_directories(pybind11 INTERFACE
+        ${PROJECT_SOURCE_DIR}/extern/pybind11/include
+        ${PYTHON_INCLUDE_DIRS})
+    target_link_libraries(pybind11 INTERFACE ${PYTHON_LIBRARIES})
+endif()
+
 target_link_libraries(storyboard PRIVATE pybind11)
 set_property(TARGET storyboard PROPERTY CXX_VISIBILITY_PRESET hidden)


### PR DESCRIPTION
Hey,

According to CMake [docs](https://cmake.org/cmake/help/latest/module/FindPythonLibs.html) _PythonLibs_ are deprecated from CMake's version 3.12 and version 3.27 removes some package components unless specific policy is set. To be honest I could not replicate the problem I was facing while working on a fork of artery: **pybind11** would not be built because of **Python.h** header missing. Instead, on master with CMake 3.31.3 I'm getting this:

```
CMake Warning (dev) at src/artery/storyboard/CMakeLists.txt:37 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

This warning is for project developers.  Use -Wno-dev to suppress it.
```

Project still compiles and scenarios with storyboard run. Still, my proposition is to use more modern [approach](https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3). Since this was added only in 3.12, I maintained old _PythonLibs_ behind a version condition.