### PR TITLE
Make Artery compatible with boost version 1.87

### DIFF
--- a/src/artery/utility/AsioScheduler.cc
+++ b/src/artery/utility/AsioScheduler.cc
@@ -20,6 +20,7 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/read.hpp>
 #include <boost/asio/steady_timer.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 
 namespace artery
 {
@@ -51,7 +52,10 @@ std::chrono::steady_clock::duration steady_clock_duration(const SimTime t)
 }
 
 
-AsioScheduler::AsioScheduler() : m_work(m_service), m_timer(m_service), m_state(FluxState::PAUSED)
+AsioScheduler::AsioScheduler() 
+	: m_work_guard(boost::asio::make_work_guard(m_service))
+	, m_timer(m_service)
+	, m_state(FluxState::PAUSED)
 {
 }
 
@@ -109,7 +113,7 @@ void AsioScheduler::startRun()
 {
 	m_state = FluxState::SYNC;
 	if (m_service.stopped()) {
-		m_service.reset();
+		m_service.restart();
 	}
 	m_reference = std::chrono::steady_clock::now();
 }

--- a/src/artery/utility/AsioScheduler.h
+++ b/src/artery/utility/AsioScheduler.h
@@ -20,6 +20,7 @@
 #include <omnetpp/cscheduler.h>
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/steady_timer.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 #include <chrono>
 #include <memory>
 
@@ -56,8 +57,8 @@ class AsioScheduler : public omnetpp::cScheduler
 		};
 
 		boost::asio::io_service m_service;
-		boost::asio::io_service::work m_work;
 		boost::asio::steady_timer m_timer;
+		boost::asio::executor_work_guard<boost::asio::io_context::executor_type> m_work_guard;
 		std::chrono::steady_clock::time_point m_reference;
 		std::chrono::steady_clock::time_point m_run_until;
 		FluxState m_state;


### PR DESCRIPTION
Hey,

Boost version 1.87 removes part of deprecated API, namely [io_context::work](https://beta.boost.org/doc/libs/1_82_0/doc/html/boost_asio/reference/io_context__work.html) and [io_context::reset](https://beta.boost.org/doc/libs/1_82_0/doc/html/boost_asio/reference/io_context/reset.html), I replaced those with recommended alternatives.

Originated from this, actually: https://github.com/riebl/artery/issues/359#issuecomment-2577935717