### PR TITLE
Adding github CI workflows

### DIFF
--- a/.github/containers/Dockerfile
+++ b/.github/containers/Dockerfile
@@ -34,8 +34,11 @@ RUN source setenv -f                                            \
 WORKDIR /
 RUN git clone --recurse --depth 1 --branch ${SUMO_TAG} https://github.com/eclipse-sumo/sumo
 WORKDIR /sumo
-RUN cmake -B build . -DCMAKE_BUILD_CONFIG=Release -DCMAKE_INSTALL_PREFIX=/sumo-prefix   \
-    && cmake --build build --parallel $(nproc --all)                                    \
+RUN cmake -B build .                                    \
+        -DCMAKE_BUILD_CONFIG=Release                    \
+        -DCMAKE_INSTALL_PREFIX=/sumo-prefix             \
+        -DFOX_LIBRARY=OFF                               \
+    && cmake --build build --parallel $(nproc --all)    \
     && cmake --install build
 
 FROM setup AS final
@@ -46,7 +49,7 @@ COPY --from=build /omnetpp/lib /omnetpp/lib
 COPY --from=build /omnetpp/images /omnetpp/images
 COPY --from=build /omnetpp/Makefile.inc /omnetpp
 
-COPY --from=build /sumo-prefix /
+COPY --from=build /sumo-prefix/ /usr/local
 
 ENV PATH=/omnetpp/bin:$PATH
 ENV SUMO_HOME=/usr/local/share/sumo

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,0 +1,30 @@
+name: Style Check
+
+on:
+  push:
+    branches-ignore:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install clang-format
+        run: |
+          sudo apt update && sudo apt install -y clang-format
+
+      - name: Run git-clang-format
+        run: |
+          git fetch origin master
+          git-clang-format              \
+            origin/master               \
+            --diff

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,50 @@
+name: Lint Check
+
+on:
+  workflow_call:
+    null
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Download runner image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: runner
+
+      - name: Load runner image
+        run: |
+          gunzip -c runner.tar.gz | docker load &&  \
+          docker run -d                             \
+            -v ${{ github.workspace }}:/workspace   \
+            -w /workspace                           \
+            --name runner                           \
+            runner:latest tail -f /dev/null
+
+      - name: Configure CMake
+        run: docker exec runner /workspace/tools/build.py -cl
+
+      - name: Download curl executable
+        run: docker exec runner bash -c "apt update && apt install -y curl"
+
+      - name: Fetch clang-format-diff script
+        run: |
+          docker exec runner curl -sSL -O https://raw.githubusercontent.com/llvm/llvm-project/main/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
+
+      - name: Run clang-tidy
+        continue-on-error: true
+        run: |
+          docker exec runner python3 clang-tidy-diff.py   \
+          -p1                                             \
+          -path .                                         \
+          < <(git diff -U0 origin/master)
+
+      - name: Stop runner
+        run: docker stop runner

--- a/.github/workflows/mainline.yaml
+++ b/.github/workflows/mainline.yaml
@@ -1,0 +1,21 @@
+name: Mainline
+
+on:
+  push:
+    branches-ignore:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  prepare:
+    uses: ./.github/workflows/prepare.yaml
+
+  lint:
+    needs: prepare
+    uses: ./.github/workflows/lint.yaml
+
+  test:
+    needs: prepare
+    uses: ./.github/workflows/test.yaml

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -1,0 +1,49 @@
+name: Prepare environment
+
+on:
+  workflow_call:
+    null
+
+jobs:
+  build-or-load:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set weekly cache key
+        id: cache-key
+        run: echo "key=runner-image-${{ runner.os }}-$(date +'%Y-%W')" >> "$GITHUB_OUTPUT"
+
+      - name: Restore runner image tarball from cache
+        id: cache-restore
+        uses: actions/cache@v4
+        with:
+          path: runner.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
+          restore-keys: |
+            runner-image-${{ runner.os }}-
+
+      - name: Checkout code
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
+
+      - name: Set up Docker buildx
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        run: docker buildx create --use || true
+
+      - name: Build Docker image
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        run: |
+          docker buildx build . \
+            --tag runner:latest \
+            --file .github/containers/Dockerfile \
+            --load
+
+      - name: Save Docker image to tarball
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        run: docker save runner:latest | gzip > runner.tar.gz
+
+      - name: Upload runner image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: runner
+          path: runner.tar.gz

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,47 @@
+name: Test
+
+on:
+  workflow_call:
+    null
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Download runner image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: runner
+
+      - name: Load runner image
+        run: |
+          gunzip -c runner.tar.gz | docker load &&  \
+          docker run -d                             \
+            -v ${{ github.workspace }}:/workspace   \
+            -w /workspace                           \
+            --name runner                           \
+            runner:latest tail -f /dev/null
+
+      - name: Install venv package
+        run: docker exec runner bash -c "apt update && apt install -y python3-venv"
+
+      - name: Create virtual environment
+        run: docker exec runner python3 -m venv .venv
+
+      - name: Install pip dependencies
+        run: docker exec runner bash -c ". ./.venv/bin/activate && pip3 install -r tools/ci/requirements.txt"
+
+      - name: Configure and build CMake
+        run: docker exec runner /workspace/tools/build.py -cb --config Release
+
+      - name: Run tests
+        run: docker exec runner bash -c ". ./.venv/bin/activate && PYTHONPATH=/workspace python3 tools/ci/run.py -l /workspace/build/Release/run-artery.ini -s /workspace/scenarios"
+
+      - name: Stop runner
+        run: docker stop runner

--- a/tools/ci/requirements.txt
+++ b/tools/ci/requirements.txt
@@ -1,4 +1,3 @@
 pandas
 pyaml
 rich
-nose2


### PR DESCRIPTION
Hey, @riebl!

I've made some workflows for QoS & testing, namely:
- format: downloads clang-format and runs against changes to master branch, fails if formatting is required;
- prepare: build minimal image for building Artery inside, caches for a week;
- lint: fetches clang-tidy-diff (doesn't come with clang distributions, like git-clang-format) and runs against diff towards master branch
- test: builds Artery and runs testing I created earlier

Current test workflow runs ~15 minutes mostly due to building INET, which takes most of that time. Probably incremental builds might help :) What do you think of those?