### PR TITLE
Make conan imports optional in builder script

### DIFF
--- a/tools/ci/requirements.txt
+++ b/tools/ci/requirements.txt
@@ -1,4 +1,3 @@
 pandas
 pyaml
 rich
-nose2


### PR DESCRIPTION
This was split from #376, change is useful in case someone just runs builder for configure/build routines and does not need any of functionality that Conan API provides.