### PR TITLE
Docker: add libraries for optional artery components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get install -y        \
     libboost-all-dev libcrypto++-dev            \
     libfox-1.6-dev libgdal-dev libproj-dev      \
     libgeographiclib-dev libxerces-c-dev        \
-    ninja-build curl python3-venv protobuf      \
-    pkg-config libzmq5-dev clang-tidy           \
+    ninja-build curl python3-venv clang-tidy    \
+    pkg-config libzmq5-dev libprotobuf-dev      \
     && rm -rf /var/lib/apt/lists/*
 
 FROM setup AS build


### PR DESCRIPTION
This PR adds:
- protobuf (needed by testbed & transfusion)
- pkg-config (used to populate zmq)
- zmq (ots)